### PR TITLE
4声体和声のMIDI禁則チェック機能を追加

### DIFF
--- a/.claude/skills/github-workflows/SKILL.md
+++ b/.claude/skills/github-workflows/SKILL.md
@@ -1,0 +1,44 @@
+---
+name: github-workflows
+description: Review pull requests, triage issues, and create releases for the midiwav repo (nobishino/midiwav) using the gh CLI. Use when the user asks to review a PR, check open issues, or cut a release.
+allowed-tools: Bash(gh *)
+---
+
+# GitHub Workflows (nobishino/midiwav)
+
+Use the `gh` CLI for all GitHub operations against this repo.
+
+## Review a PR
+```
+gh pr view <PR_NUMBER> --json title,body,files,reviews,comments,additions,deletions
+gh pr diff <PR_NUMBER>
+```
+Check for: correctness bugs, missing test coverage (this repo uses `go test`,
+golden files under `testdata/*.wav` updated via `go test -update`), and
+whether commit/PR titles follow the repo's existing style (see `git log`).
+
+## List and triage issues
+```
+gh issue list --state open --json number,title,labels,updatedAt
+gh issue view <ISSUE_NUMBER>
+```
+
+## Create a release
+This repo's convention (see git log) is a dedicated PR titled
+`Release for vX.Y.Z`, merged before tagging. To cut a release:
+```
+gh pr create --title "Release for vX.Y.Z" --body "<summary of changes>"
+# after merge:
+gh release create vX.Y.Z --title "vX.Y.Z" --generate-notes
+```
+Confirm the version bump and changelog content with the user before creating
+the PR or the release — both are visible, hard-to-reverse actions.
+
+## Check CI / PR status
+```
+gh pr checks <PR_NUMBER>
+gh pr status
+```
+
+Always summarize findings for the user before taking any action that creates,
+merges, or publishes something (PRs, releases, comments).

--- a/harmony_check.go
+++ b/harmony_check.go
@@ -1,0 +1,457 @@
+package main
+
+// 四声体和声のMIDI禁則チェッカー（芸大和声ベース）
+//
+// 前提:
+//   - SATBが4トラックに分かれていること（上から S, A, T, B の順）。
+//   - ファイル名に調をドイツ語音名で含めること（例: es-moll.mid, As-dur.mid）。
+//     転調しない課題向け。調が読み取れない場合、綴り依存の検査はスキップする。
+//
+// チェック項目:
+//   - 連続1度・5度・8度（全声部ペア、反行連続を含む）
+//   - 並達1度・5度・8度（外声間、ソプラノが跳躍のとき）
+//   - 声部の交差（同一和音内）
+//   - 隣接上3声の間隔（S-A, A-T が1オクターブ以内）
+//   - 音域（芸大和声の声域表ベース・参考警告）
+//   - 増音程の旋律進行（要・調）。増1度（半音階的変位）は許容として除外
+//   - 減音程の旋律跳躍（要・調）。参考表示（跳躍後は反行が望ましい）
+//   - 対斜（要・調）。参考表示（教科書の許容例外と照合すること）
+
+import (
+	"fmt"
+	"math"
+	"path/filepath"
+	"regexp"
+	"slices"
+	"strings"
+
+	"gitlab.com/gomidi/midi/v2/smf"
+)
+
+var voiceNames = [4]string{"S", "A", "T", "B"}
+
+// 参考: 芸大和声の声域（要教科書照合）
+var voiceRanges = [4][2]uint8{
+	{60, 81}, // S
+	{53, 74}, // A
+	{48, 69}, // T
+	{40, 62}, // B
+}
+
+var noteLetters = [7]string{"C", "D", "E", "F", "G", "A", "B"}
+
+// basePitchClass[i] は noteLetters[i] のピッチクラス。
+// 度数(g%7)を添字にすると、その度数の完全/長音程の半音数にもなる。
+var basePitchClass = [7]int{0, 2, 4, 5, 7, 9, 11}
+
+var accidentalStr = map[int]string{-2: "bb", -1: "b", 0: "", 1: "#", 2: "##"}
+
+var qualityNames = map[int]string{-2: "重減", -1: "減", 1: "増", 2: "重増"}
+
+// noteSpelling は音名の綴り（幹音と変化）。
+type noteSpelling struct {
+	letter int // noteLetters の添字
+	acc    int // 変化（-2〜+2）
+}
+
+// germanNames はドイツ語音名 → 綴り。b はドイツ語の B♭、h が B♮。
+var germanNames = map[string]noteSpelling{
+	"c": {0, 0}, "cis": {0, 1}, "ces": {0, -1},
+	"d": {1, 0}, "dis": {1, 1}, "des": {1, -1},
+	"e": {2, 0}, "eis": {2, 1}, "es": {2, -1},
+	"f": {3, 0}, "fis": {3, 1}, "fes": {3, -1},
+	"g": {4, 0}, "gis": {4, 1}, "ges": {4, -1},
+	"a": {5, 0}, "ais": {5, 1}, "as": {5, -1},
+	"h": {6, 0}, "his": {6, 1}, "b": {6, -1},
+}
+
+type keySignature struct {
+	tonic noteSpelling
+	mode  string // "dur" または "moll"
+}
+
+func (k keySignature) String() string {
+	return noteLetters[k.tonic.letter] + accidentalStr[k.tonic.acc] + "-" + k.mode
+}
+
+var keyPattern = regexp.MustCompile(`(?:^|[^a-z])([a-h](?:is|es|s)?)[-_ ]?(dur|moll)`)
+
+// parseKeyFromFilename はファイル名のドイツ語音名から調を読み取る（例: es-moll.mid）。
+func parseKeyFromFilename(path string) (keySignature, bool) {
+	base := filepath.Base(path)
+	stem := strings.ToLower(strings.TrimSuffix(base, filepath.Ext(base)))
+	m := keyPattern.FindStringSubmatch(stem)
+	if m == nil {
+		return keySignature{}, false
+	}
+	tonic, ok := germanNames[m[1]]
+	if !ok {
+		return keySignature{}, false
+	}
+	return keySignature{tonic: tonic, mode: m[2]}, true
+}
+
+// flatSpellingTable は調が不明なときの代用（黒鍵はフラット表記）。
+var flatSpellingTable = [12]noteSpelling{
+	{0, 0}, {1, -1}, {1, 0}, {2, -1}, {2, 0}, {3, 0},
+	{4, -1}, {4, 0}, {5, -1}, {5, 0}, {6, -1}, {6, 0},
+}
+
+// buildSpellingTable はピッチクラス → 綴りの12音表を作る。全音階音は音階の綴り、
+// 半音階音は「下の音階音の上方変位」を優先し、無理なら上の音の下方変位。
+func buildSpellingTable(key keySignature) [12]noteSpelling {
+	steps := [7]int{2, 2, 1, 2, 2, 2, 1}
+	if key.mode == "moll" {
+		steps = [7]int{2, 1, 2, 2, 1, 2, 2}
+	}
+	var table [12]noteSpelling
+	var isScaleTone [12]bool
+	li := key.tonic.letter
+	pc := mod12(basePitchClass[li] + key.tonic.acc)
+	for i := range 7 {
+		if i > 0 {
+			pc = mod12(pc + steps[i-1])
+			li = (li + 1) % 7
+		}
+		table[pc] = noteSpelling{li, mod12(pc-basePitchClass[li]+6) - 6}
+		isScaleTone[pc] = true
+	}
+	for pc := range 12 {
+		if isScaleTone[pc] {
+			continue
+		}
+		lo, hi := table[mod12(pc-1)], table[mod12(pc+1)]
+		if abs(lo.acc+1) <= 2 {
+			table[pc] = noteSpelling{lo.letter, lo.acc + 1}
+		} else {
+			table[pc] = noteSpelling{hi.letter, hi.acc - 1}
+		}
+	}
+	return table
+}
+
+// spellNote はMIDIノート番号を綴りとオクターブに分解する。
+func spellNote(note uint8, table [12]noteSpelling) (noteSpelling, int) {
+	sp := table[note%12]
+	octave := floorDiv(int(note)-basePitchClass[sp.letter]-sp.acc, 12) - 1
+	return sp, octave
+}
+
+func noteName(note uint8, table [12]noteSpelling) string {
+	sp, octave := spellNote(note, table)
+	return fmt.Sprintf("%s%s%d", noteLetters[sp.letter], accidentalStr[sp.acc], octave)
+}
+
+// intervalQuality は旋律音程を (度数, 変位, 質の名前) で返す。
+// 変位: 0=完全/長/短, +1=増, -1=減 など。
+func intervalQuality(n1, n2 uint8, table [12]noteSpelling) (int, int, string) {
+	sp1, o1 := spellNote(n1, table)
+	sp2, o2 := spellNote(n2, table)
+	g := abs((o2*7 + sp2.letter) - (o1*7 + sp1.letter)) // 度数-1
+	c := abs(int(n2) - int(n1))                         // 半音数
+	dev := c - (basePitchClass[g%7] + 12*(g/7))
+	perfect := g%7 == 0 || g%7 == 3 || g%7 == 4
+	if !perfect && dev == -1 {
+		return g + 1, 0, "短"
+	}
+	if dev == 0 {
+		if perfect {
+			return g + 1, 0, "完全"
+		}
+		return g + 1, 0, "長"
+	}
+	if !perfect && dev < -1 {
+		dev++
+	}
+	name, ok := qualityNames[dev]
+	if !ok {
+		name = fmt.Sprintf("dev%d", dev)
+	}
+	return g + 1, dev, name
+}
+
+// chord は同時に発音される4声の音（S, A, T, B の順）。
+type chord struct {
+	beat  float64 // 曲頭からの拍数（4分音符換算）
+	notes [4]uint8
+}
+
+// chorale は4声体とみなしたMIDIから抽出した和音列。
+type chorale struct {
+	chords          []chord
+	beatsPerMeasure float64 // 1小節の拍数（4分音符換算）
+	beatUnit        float64 // 1拍の長さ（4分音符換算）
+}
+
+func (c *chorale) pos(beat float64) string {
+	measure := int(beat/c.beatsPerMeasure) + 1
+	beatInMeasure := int(math.Mod(beat, c.beatsPerMeasure)/c.beatUnit) + 1
+	return fmt.Sprintf("%d小節%d拍目", measure, beatInMeasure)
+}
+
+// extractChorale はSMFから4声体の和音列を抽出する。音符のあるトラックが
+// ちょうど4本（上から S, A, T, B）でない場合は4声体でないとみなす。
+// 和音は4声すべてが同時に発音するオンセットから作る。
+func extractChorale(s *smf.SMF) (*chorale, bool) {
+	metricTicks, ok := s.TimeFormat.(smf.MetricTicks)
+	if !ok {
+		return nil, false
+	}
+	num, denom := uint8(4), uint8(4)
+	var parts []map[int64]uint8
+	for _, track := range s.Tracks {
+		var t int64
+		notes := make(map[int64]uint8)
+		for _, ev := range track {
+			t += int64(ev.Delta)
+			var key, velocity uint8
+			if ev.Message.GetNoteOn(nil, &key, &velocity) && velocity > 0 {
+				notes[t] = key
+			} else {
+				ev.Message.GetMetaMeter(&num, &denom)
+			}
+		}
+		if len(notes) > 0 {
+			parts = append(parts, notes)
+		}
+	}
+	if len(parts) != 4 {
+		return nil, false
+	}
+	onsetSet := make(map[int64]struct{})
+	for _, p := range parts {
+		for t := range p {
+			onsetSet[t] = struct{}{}
+		}
+	}
+	onsets := make([]int64, 0, len(onsetSet))
+	for t := range onsetSet {
+		onsets = append(onsets, t)
+	}
+	slices.Sort(onsets)
+
+	var chords []chord
+	for _, o := range onsets {
+		var notes [4]uint8
+		all := true
+		for i, p := range parts {
+			n, ok := p[o]
+			if !ok {
+				all = false
+				break
+			}
+			notes[i] = n
+		}
+		if all {
+			chords = append(chords, chord{beat: float64(o) / float64(metricTicks), notes: notes})
+		}
+	}
+	if len(chords) == 0 {
+		return nil, false
+	}
+	return &chorale{
+		chords:          chords,
+		beatsPerMeasure: float64(num) * 4 / float64(denom),
+		beatUnit:        4 / float64(denom),
+	}, true
+}
+
+type harmonyIssue struct {
+	warn bool // true: ⚠ 禁則, false: ℹ 参考
+	msg  string
+}
+
+// checkBasic は綴りに依存しない検査: 交差・間隔・音域・連続・並達。
+func checkBasic(ch *chorale, table [12]noteSpelling) []harmonyIssue {
+	var issues []harmonyIssue
+	nm := func(n uint8) string { return noteName(n, table) }
+	for _, c := range ch.chords {
+		s, a, t, b := c.notes[0], c.notes[1], c.notes[2], c.notes[3]
+		if !(s >= a && a >= t && t >= b) {
+			names := make([]string, 4)
+			for i, n := range c.notes {
+				names[i] = nm(n)
+			}
+			issues = append(issues, harmonyIssue{true,
+				fmt.Sprintf("[交差] %s: %s", ch.pos(c.beat), strings.Join(names, " "))})
+		}
+		if int(s)-int(a) > 12 {
+			issues = append(issues, harmonyIssue{true,
+				fmt.Sprintf("[間隔] %s: S-A が %d 半音（8度超）", ch.pos(c.beat), int(s)-int(a))})
+		}
+		if int(a)-int(t) > 12 {
+			issues = append(issues, harmonyIssue{true,
+				fmt.Sprintf("[間隔] %s: A-T が %d 半音（8度超）", ch.pos(c.beat), int(a)-int(t))})
+		}
+		for i, n := range c.notes {
+			if n < voiceRanges[i][0] || n > voiceRanges[i][1] {
+				issues = append(issues, harmonyIssue{false,
+					fmt.Sprintf("[音域?] %s: %s の %s が声域外の可能性（要照合）", ch.pos(c.beat), voiceNames[i], nm(n))})
+			}
+		}
+	}
+	for k := 0; k+1 < len(ch.chords); k++ {
+		c1, c2 := ch.chords[k], ch.chords[k+1]
+		for i := range 4 {
+			for j := i + 1; j < 4; j++ {
+				hi1, lo1, hi2, lo2 := c1.notes[i], c1.notes[j], c2.notes[i], c2.notes[j]
+				int1, int2 := mod12(int(hi1)-int(lo1)), mod12(int(hi2)-int(lo2))
+				moved := hi1 != hi2 && lo1 != lo2
+				pair := voiceNames[i] + "-" + voiceNames[j]
+				if moved && int1 == int2 && (int1 == 0 || int1 == 7) {
+					kind := "5度"
+					if int1 == 0 {
+						kind = "8度/1度"
+					}
+					issues = append(issues, harmonyIssue{true,
+						fmt.Sprintf("[連続%s] %s→%s %s: %s/%s → %s/%s",
+							kind, ch.pos(c1.beat), ch.pos(c2.beat), pair,
+							nm(hi1), nm(lo1), nm(hi2), nm(lo2))})
+				}
+				// 並達は外声間のみ、ソプラノが跳躍して同方向のとき
+				if i == 0 && j == 3 && moved && (int2 == 0 || int2 == 7) && int1 != int2 {
+					sameDir := (int(hi2)-int(hi1))*(int(lo2)-int(lo1)) > 0
+					if sameDir && abs(int(hi2)-int(hi1)) > 2 {
+						kind := "5度"
+						if int2 == 0 {
+							kind = "8度"
+						}
+						issues = append(issues, harmonyIssue{true,
+							fmt.Sprintf("[並達%s] %s→%s 外声: %s/%s → %s/%s",
+								kind, ch.pos(c1.beat), ch.pos(c2.beat),
+								nm(hi1), nm(lo1), nm(hi2), nm(lo2))})
+					}
+				}
+			}
+		}
+	}
+	return issues
+}
+
+// checkSpelled は調の綴りに依存する検査: 増・減音程の旋律進行、対斜。
+func checkSpelled(ch *chorale, table [12]noteSpelling) []harmonyIssue {
+	var issues []harmonyIssue
+	nm := func(n uint8) string { return noteName(n, table) }
+	for k := 0; k+1 < len(ch.chords); k++ {
+		c1, c2 := ch.chords[k], ch.chords[k+1]
+		for v := range 4 {
+			n1, n2 := c1.notes[v], c2.notes[v]
+			if n1 == n2 {
+				continue
+			}
+			size, dev, q := intervalQuality(n1, n2, table)
+			arrow := "↓"
+			if n2 > n1 {
+				arrow = "↑"
+			}
+			if dev >= 1 && size >= 2 {
+				issues = append(issues, harmonyIssue{true,
+					fmt.Sprintf("[増音程] %s→%s %s: %s %s %s（%s%d度）",
+						ch.pos(c1.beat), ch.pos(c2.beat), voiceNames[v], nm(n1), arrow, nm(n2), q, size)})
+			} else if dev <= -1 {
+				issues = append(issues, harmonyIssue{false,
+					fmt.Sprintf("[減音程] %s→%s %s: %s %s %s（%s%d度・跳躍後は反行が望ましい）",
+						ch.pos(c1.beat), ch.pos(c2.beat), voiceNames[v], nm(n1), arrow, nm(n2), q, size)})
+			}
+		}
+		// 対斜: 同じ幹音が隣接和音で異なる変化を持ち、その半音変化が同一声部で起きていない
+		var sp1, sp2 [4]noteSpelling
+		for i := range 4 {
+			sp1[i], _ = spellNote(c1.notes[i], table)
+			sp2[i], _ = spellNote(c2.notes[i], table)
+		}
+		for i := range 4 {
+			for j := range 4 {
+				if sp1[i].letter != sp2[j].letter || sp1[i].acc == sp2[j].acc || i == j {
+					continue
+				}
+				if sp2[i] == sp2[j] { // 同声部でも同じ変化に到達
+					continue
+				}
+				if sp1[j] == sp1[i] {
+					continue
+				}
+				issues = append(issues, harmonyIssue{false,
+					fmt.Sprintf("[対斜] %s→%s: %s の %s と %s の %s（要・教科書の許容例外と照合）",
+						ch.pos(c1.beat), ch.pos(c2.beat),
+						voiceNames[i], nm(c1.notes[i]), voiceNames[j], nm(c2.notes[j]))})
+			}
+		}
+	}
+	return issues
+}
+
+// harmonyReport は4声体和声の禁則チェックを実行し、添削レポートを返す。
+// 4声体とみなせないMIDIの場合は ok=false を返す。
+func harmonyReport(s *smf.SMF, path string) (string, bool) {
+	ch, ok := extractChorale(s)
+	if !ok {
+		return "", false
+	}
+	key, hasKey := parseKeyFromFilename(path)
+	table := flatSpellingTable
+	if hasKey {
+		table = buildSpellingTable(key)
+	}
+
+	var b strings.Builder
+	if hasKey {
+		fmt.Fprintf(&b, "調: %s（ファイル名から）\n", key)
+	} else {
+		b.WriteString("注意: ファイル名から調を読み取れず。増音程・減音程・対斜の検査はスキップし、綴りはフラット表記で代用。\n")
+	}
+	fmt.Fprintf(&b, "%d 和音を検査:\n", len(ch.chords))
+	for _, c := range ch.chords {
+		fmt.Fprintf(&b, "  %s ", ch.pos(c.beat))
+		for i, n := range c.notes {
+			fmt.Fprintf(&b, " %s:%s", voiceNames[i], noteName(n, table))
+		}
+		b.WriteByte('\n')
+	}
+
+	issues := checkBasic(ch, table)
+	if hasKey {
+		issues = append(issues, checkSpelled(ch, table)...)
+	}
+	b.WriteByte('\n')
+	var warns, infos int
+	for _, is := range issues {
+		if is.warn {
+			b.WriteString("⚠ " + is.msg + "\n")
+			warns++
+		}
+	}
+	for _, is := range issues {
+		if !is.warn {
+			b.WriteString("ℹ " + is.msg + "\n")
+			infos++
+		}
+	}
+	if warns == 0 {
+		if infos > 0 {
+			b.WriteString("✓ 禁則違反は検出されませんでした（参考警告あり）\n")
+		} else {
+			b.WriteString("✓ 禁則違反は検出されませんでした\n")
+		}
+	}
+	return b.String(), true
+}
+
+func mod12(x int) int {
+	return ((x % 12) + 12) % 12
+}
+
+func abs(x int) int {
+	if x < 0 {
+		return -x
+	}
+	return x
+}
+
+func floorDiv(a, b int) int {
+	q := a / b
+	if (a%b != 0) && ((a < 0) != (b < 0)) {
+		q--
+	}
+	return q
+}

--- a/harmony_check_test.go
+++ b/harmony_check_test.go
@@ -1,0 +1,263 @@
+package main
+
+import (
+	"strings"
+	"testing"
+
+	"gitlab.com/gomidi/midi/v2"
+	"gitlab.com/gomidi/midi/v2/smf"
+)
+
+func TestParseKeyFromFilename(t *testing.T) {
+	tests := []struct {
+		path string
+		want string
+		ok   bool
+	}{
+		{"es-moll.mid", "Eb-moll", true},
+		{"As-dur.mid", "Ab-dur", true},
+		{"/path/to/課題1_h-moll.mid", "B-moll", true},
+		{"fis_dur.mid", "F#-dur", true},
+		{"b-dur.mid", "Bb-dur", true},
+		{"C-Dur.mid", "C-dur", true},
+		{"nokey.mid", "", false},
+		{"melody.mid", "", false},
+	}
+	for _, tt := range tests {
+		key, ok := parseKeyFromFilename(tt.path)
+		if ok != tt.ok {
+			t.Errorf("parseKeyFromFilename(%q) ok = %v, want %v", tt.path, ok, tt.ok)
+			continue
+		}
+		if ok && key.String() != tt.want {
+			t.Errorf("parseKeyFromFilename(%q) = %s, want %s", tt.path, key, tt.want)
+		}
+	}
+}
+
+func TestBuildSpellingTable(t *testing.T) {
+	mustKey := func(name string) keySignature {
+		t.Helper()
+		key, ok := parseKeyFromFilename(name)
+		if !ok {
+			t.Fatalf("failed to parse key from %q", name)
+		}
+		return key
+	}
+
+	// C-dur: 半音階音は下の音階音の上方変位（C# D# F# G# A#）
+	cdur := buildSpellingTable(mustKey("c-dur.mid"))
+	for pc, want := range map[int]noteSpelling{
+		0: {0, 0}, 1: {0, 1}, 3: {1, 1}, 4: {2, 0}, 6: {3, 1}, 10: {5, 1}, 11: {6, 0},
+	} {
+		if cdur[pc] != want {
+			t.Errorf("C-dur table[%d] = %v, want %v", pc, cdur[pc], want)
+		}
+	}
+
+	// es-moll: 音階音は Eb F Gb Ab Bb Cb Db
+	esmoll := buildSpellingTable(mustKey("es-moll.mid"))
+	for pc, want := range map[int]noteSpelling{
+		3: {2, -1}, 5: {3, 0}, 6: {4, -1}, 8: {5, -1}, 10: {6, -1}, 11: {0, -1}, 1: {1, -1},
+	} {
+		if esmoll[pc] != want {
+			t.Errorf("es-moll table[%d] = %v, want %v", pc, esmoll[pc], want)
+		}
+	}
+}
+
+func TestNoteName(t *testing.T) {
+	if got := noteName(60, flatSpellingTable); got != "C4" {
+		t.Errorf("noteName(60) = %s, want C4", got)
+	}
+	if got := noteName(61, flatSpellingTable); got != "Db4" {
+		t.Errorf("noteName(61) = %s, want Db4", got)
+	}
+	key, _ := parseKeyFromFilename("c-dur.mid")
+	if got := noteName(61, buildSpellingTable(key)); got != "C#4" {
+		t.Errorf("noteName(61, C-dur) = %s, want C#4", got)
+	}
+}
+
+func TestIntervalQuality(t *testing.T) {
+	key, _ := parseKeyFromFilename("c-dur.mid")
+	table := buildSpellingTable(key)
+	tests := []struct {
+		n1, n2   uint8
+		wantSize int
+		wantName string
+	}{
+		{65, 71, 4, "増"},  // F4 → B4: 増4度
+		{71, 77, 5, "減"},  // B4 → F5: 減5度
+		{60, 64, 3, "長"},  // C4 → E4: 長3度
+		{64, 60, 3, "長"},  // 下行でも同じ
+		{60, 67, 5, "完全"}, // C4 → G4: 完全5度
+	}
+	for _, tt := range tests {
+		size, _, name := intervalQuality(tt.n1, tt.n2, table)
+		if size != tt.wantSize || name != tt.wantName {
+			t.Errorf("intervalQuality(%d, %d) = %d, %s, want %d, %s",
+				tt.n1, tt.n2, size, name, tt.wantSize, tt.wantName)
+		}
+	}
+	// a-moll における F4 → G#4 は増2度
+	amoll, _ := parseKeyFromFilename("a-moll.mid")
+	size, dev, name := intervalQuality(65, 68, buildSpellingTable(amoll))
+	if size != 2 || dev != 1 || name != "増" {
+		t.Errorf("intervalQuality(F4, G#4, a-moll) = %d, %d, %s, want 2, 1, 増", size, dev, name)
+	}
+}
+
+// buildChoraleSMF は各和音が全音符で並ぶSATB 4トラックのSMFを作る。
+func buildChoraleSMF(t *testing.T, chords ...[4]uint8) *smf.SMF {
+	t.Helper()
+	s := smf.New()
+	for v := range 4 {
+		var tr smf.Track
+		if v == 0 {
+			tr.Add(0, smf.MetaTempo(120))
+			tr.Add(0, smf.MetaMeter(4, 4))
+		}
+		for _, c := range chords {
+			tr.Add(0, midi.NoteOn(0, c[v], 100))
+			tr.Add(4*960, midi.NoteOff(0, c[v]))
+		}
+		tr.Close(0)
+		if err := s.Add(tr); err != nil {
+			t.Fatal(err)
+		}
+	}
+	return s
+}
+
+func TestExtractChorale(t *testing.T) {
+	s := buildChoraleSMF(t,
+		[4]uint8{72, 67, 64, 60},
+		[4]uint8{71, 67, 62, 55},
+	)
+	ch, ok := extractChorale(s)
+	if !ok {
+		t.Fatal("extractChorale: not recognized as a 4-voice chorale")
+	}
+	if len(ch.chords) != 2 {
+		t.Fatalf("got %d chords, want 2", len(ch.chords))
+	}
+	if ch.chords[1].beat != 4 {
+		t.Errorf("second chord beat = %f, want 4", ch.chords[1].beat)
+	}
+	if ch.pos(ch.chords[1].beat) != "2小節1拍目" {
+		t.Errorf("pos = %s, want 2小節1拍目", ch.pos(ch.chords[1].beat))
+	}
+
+	// トラックが3本しかない場合は4声体とみなさない
+	s3 := smf.New()
+	for v := range 3 {
+		var tr smf.Track
+		tr.Add(0, midi.NoteOn(0, uint8(60+v), 100))
+		tr.Add(960, midi.NoteOff(0, uint8(60+v)))
+		tr.Close(0)
+		if err := s3.Add(tr); err != nil {
+			t.Fatal(err)
+		}
+	}
+	if _, ok := extractChorale(s3); ok {
+		t.Error("extractChorale: 3-track SMF should not be recognized as a chorale")
+	}
+}
+
+func TestHarmonyReportClean(t *testing.T) {
+	// C-dur: I → V。禁則なし。
+	s := buildChoraleSMF(t,
+		[4]uint8{72, 67, 64, 60}, // C5 G4 E4 C4
+		[4]uint8{71, 67, 62, 55}, // B4 G4 D4 G3
+	)
+	report, ok := harmonyReport(s, "c-dur.mid")
+	if !ok {
+		t.Fatal("harmonyReport: not recognized as a 4-voice chorale")
+	}
+	if !strings.Contains(report, "調: C-dur") {
+		t.Errorf("report should contain key, got:\n%s", report)
+	}
+	if !strings.Contains(report, "✓ 禁則違反は検出されませんでした") {
+		t.Errorf("report should be clean, got:\n%s", report)
+	}
+}
+
+func TestHarmonyReportParallelFifth(t *testing.T) {
+	// S-A 間の連続5度: C5/F4 → D5/G4
+	s := buildChoraleSMF(t,
+		[4]uint8{72, 65, 57, 53},
+		[4]uint8{74, 67, 59, 55},
+	)
+	report, ok := harmonyReport(s, "c-dur.mid")
+	if !ok {
+		t.Fatal("harmonyReport: not recognized as a 4-voice chorale")
+	}
+	if !strings.Contains(report, "[連続5度] 1小節1拍目→2小節1拍目 S-A") {
+		t.Errorf("report should contain parallel fifth S-A, got:\n%s", report)
+	}
+	if strings.Contains(report, "✓") {
+		t.Errorf("report should not be clean, got:\n%s", report)
+	}
+}
+
+func TestHarmonyReportCrossingAndSpacing(t *testing.T) {
+	// 1和音目: A(65) が S(64) より高い → 交差。2和音目: S-A が 8度超。
+	s := buildChoraleSMF(t,
+		[4]uint8{64, 65, 57, 48},
+		[4]uint8{76, 62, 55, 48},
+	)
+	report, ok := harmonyReport(s, "c-dur.mid")
+	if !ok {
+		t.Fatal("harmonyReport: not recognized as a 4-voice chorale")
+	}
+	if !strings.Contains(report, "[交差] 1小節1拍目") {
+		t.Errorf("report should contain voice crossing, got:\n%s", report)
+	}
+	if !strings.Contains(report, "[間隔] 2小節1拍目: S-A が 14 半音") {
+		t.Errorf("report should contain spacing violation, got:\n%s", report)
+	}
+}
+
+func TestCheckSpelledAugmentedAndCrossRelation(t *testing.T) {
+	amoll, _ := parseKeyFromFilename("a-moll.mid")
+	table := buildSpellingTable(amoll)
+
+	// A(声部2番目)が F4 → G#4 と増2度で進行
+	aug := &chorale{
+		chords: []chord{
+			{beat: 0, notes: [4]uint8{72, 65, 60, 45}},
+			{beat: 4, notes: [4]uint8{71, 68, 59, 52}},
+		},
+		beatsPerMeasure: 4, beatUnit: 1,
+	}
+	issues := checkSpelled(aug, table)
+	found := false
+	for _, is := range issues {
+		if is.warn && strings.Contains(is.msg, "[増音程]") && strings.Contains(is.msg, "F4 ↑ G#4（増2度）") {
+			found = true
+		}
+	}
+	if !found {
+		t.Errorf("expected augmented second issue, got: %+v", issues)
+	}
+
+	// 対斜: T の G3 → 次の和音で S に G#4
+	cross := &chorale{
+		chords: []chord{
+			{beat: 0, notes: [4]uint8{71, 64, 55, 52}},
+			{beat: 4, notes: [4]uint8{68, 64, 57, 52}},
+		},
+		beatsPerMeasure: 4, beatUnit: 1,
+	}
+	issues = checkSpelled(cross, table)
+	found = false
+	for _, is := range issues {
+		if !is.warn && strings.Contains(is.msg, "[対斜]") && strings.Contains(is.msg, "T の G3 と S の G#4") {
+			found = true
+		}
+	}
+	if !found {
+		t.Errorf("expected cross relation issue, got: %+v", issues)
+	}
+}

--- a/main.go
+++ b/main.go
@@ -5,8 +5,12 @@ import (
 	"fmt"
 	"log"
 	"os"
+	"path/filepath"
 	"strings"
 	"time"
+	"unicode/utf8"
+
+	"gitlab.com/gomidi/midi/v2/smf"
 )
 
 func main() {
@@ -95,10 +99,59 @@ func processFile(srcPath string, discordWebhookURL string) error {
 		return fmt.Errorf("failed to convert MIDI to WAV: %w", err)
 	}
 
+	report := checkHarmony(srcMIDI, srcPath)
+	if report != "" {
+		fmt.Print(report)
+	}
+
 	if discordWebhookURL != "" {
-		if err := postToDiscord(discordWebhookURL, srcMIDI, dstWAV); err != nil {
+		content, files := buildDiscordPost(srcMIDI, dstWAV, report)
+		if err := postToDiscord(discordWebhookURL, content, files...); err != nil {
 			log.Println(err)
 		}
 	}
 	return nil
+}
+
+// checkHarmony runs the harmony rule check if the MIDI looks like a
+// four-part chorale. It returns an empty report otherwise.
+func checkHarmony(srcMIDI *os.File, srcPath string) string {
+	if _, err := srcMIDI.Seek(0, 0); err != nil {
+		return ""
+	}
+	smfData, err := smf.ReadFrom(srcMIDI)
+	if err != nil {
+		return ""
+	}
+	report, ok := harmonyReport(smfData, srcPath)
+	if !ok {
+		return ""
+	}
+	return report
+}
+
+// discordContentLimit is Discord's maximum message content length in characters.
+const discordContentLimit = 2000
+
+func buildDiscordPost(srcMIDI, dstWAV *os.File, report string) (string, []discordFile) {
+	content := "MIDIファイルとWAVファイルを保存しました"
+	var files []discordFile
+	for _, f := range []*os.File{srcMIDI, dstWAV} {
+		if _, err := f.Seek(0, 0); err != nil {
+			log.Println(err)
+			continue
+		}
+		files = append(files, discordFile{name: filepath.Base(f.Name()), r: f})
+	}
+	if report != "" {
+		withReport := content + "\n4声体和声の添削結果:\n```\n" + report + "```"
+		if utf8.RuneCountInString(withReport) <= discordContentLimit {
+			content = withReport
+		} else {
+			content += "\n4声体和声の添削結果が長いためファイルとして添付します"
+			name := strings.TrimSuffix(filepath.Base(srcMIDI.Name()), ".mid") + "-check.txt"
+			files = append(files, discordFile{name: name, r: strings.NewReader(report)})
+		}
+	}
+	return content, files
 }

--- a/main_test.go
+++ b/main_test.go
@@ -1,0 +1,60 @@
+package main
+
+import (
+	"os"
+	"strings"
+	"testing"
+)
+
+func TestBuildDiscordPost(t *testing.T) {
+	newTempFile := func(t *testing.T, name string) *os.File {
+		t.Helper()
+		f, err := os.CreateTemp(t.TempDir(), name)
+		if err != nil {
+			t.Fatal(err)
+		}
+		t.Cleanup(func() { f.Close() })
+		return f
+	}
+
+	t.Run("no report", func(t *testing.T) {
+		srcMIDI := newTempFile(t, "song-*.mid")
+		dstWAV := newTempFile(t, "song-*.wav")
+		content, files := buildDiscordPost(srcMIDI, dstWAV, "")
+		if strings.Contains(content, "添削") {
+			t.Errorf("content should not mention harmony report, got: %s", content)
+		}
+		if len(files) != 2 {
+			t.Errorf("got %d files, want 2 (midi + wav)", len(files))
+		}
+	})
+
+	t.Run("short report is inlined", func(t *testing.T) {
+		srcMIDI := newTempFile(t, "song-*.mid")
+		dstWAV := newTempFile(t, "song-*.wav")
+		content, files := buildDiscordPost(srcMIDI, dstWAV, "✓ 禁則違反は検出されませんでした\n")
+		if !strings.Contains(content, "✓ 禁則違反は検出されませんでした") {
+			t.Errorf("content should contain the report inline, got: %s", content)
+		}
+		if len(files) != 2 {
+			t.Errorf("got %d files, want 2 (no extra report file)", len(files))
+		}
+	})
+
+	t.Run("long report is attached as a file", func(t *testing.T) {
+		srcMIDI := newTempFile(t, "song-*.mid")
+		dstWAV := newTempFile(t, "song-*.wav")
+		longReport := strings.Repeat("あ", discordContentLimit)
+		content, files := buildDiscordPost(srcMIDI, dstWAV, longReport)
+		if strings.Contains(content, longReport) {
+			t.Errorf("content should not inline the long report, got: %s", content)
+		}
+		if len(files) != 3 {
+			t.Fatalf("got %d files, want 3 (midi + wav + report)", len(files))
+		}
+		reportFile := files[2]
+		if !strings.HasSuffix(reportFile.name, "-check.txt") {
+			t.Errorf("report file name = %s, want suffix -check.txt", reportFile.name)
+		}
+	})
+}

--- a/post_discord.go
+++ b/post_discord.go
@@ -7,11 +7,15 @@ import (
 	"io"
 	"mime/multipart"
 	"net/http"
-	"os"
-	"path/filepath"
 )
 
-func postToDiscord(webhookURL string, fs ...*os.File) error {
+// discordFile is a file attached to a Discord webhook post.
+type discordFile struct {
+	name string
+	r    io.Reader
+}
+
+func postToDiscord(webhookURL string, content string, files ...discordFile) error {
 	if webhookURL == "" {
 		return fmt.Errorf("webhook URL is empty")
 	}
@@ -20,7 +24,7 @@ func postToDiscord(webhookURL string, fs ...*os.File) error {
 
 	// payload_json
 	payload := map[string]any{
-		"content": "MIDIファイルとWAVファイルを保存しました",
+		"content": content,
 	}
 	pb, err := json.Marshal(payload)
 	if err != nil {
@@ -30,18 +34,12 @@ func postToDiscord(webhookURL string, fs ...*os.File) error {
 		return err
 	}
 
-	for i, f := range fs {
-		// ファイル先頭に戻す
-		if _, err := f.Seek(0, 0); err != nil {
-			return err
-		}
-
-		// file
-		fw, err := w.CreateFormFile(fmt.Sprintf("file[%d]", i), filepath.Base(f.Name()))
+	for i, f := range files {
+		fw, err := w.CreateFormFile(fmt.Sprintf("file[%d]", i), f.name)
 		if err != nil {
 			return err
 		}
-		if _, err := io.Copy(fw, f); err != nil {
+		if _, err := io.Copy(fw, f.r); err != nil {
 			return err
 		}
 	}


### PR DESCRIPTION
## Summary
- 4トラック(S/A/T/B)構成のMIDIを4声体和声とみなし、連続1・5・8度、並達1・5・8度、声部交差、声部間隔、声域、増音程進行、減音程跳躍、対斜を検査する `harmonyReport` を追加 (harmony_check.go)
- ファイル名からドイツ語音名で調を読み取り(例: `es-moll.mid`)、調に基づく異名同音の綴りで結果を表示。調が読み取れない場合は綴り依存の検査をスキップ
- 4声体と判定できた場合のみ添削結果を実行し、既存のMIDI→WAV変換・Discord投稿フローに組み込み (main.go)
- 添削レポートが短ければDiscordメッセージ本文に埋め込み、長い場合は`-check.txt`として添付ファイルに切り出す (main.go, post_discord.go)

Closes #22

## Test plan
- [x] `go build ./...`
- [x] `go test ./...`
- [x] `gofmt -l .` (no output)
- [x] `go vet ./...`