### PR TITLE
調が既知の場合に和音記号（度数・種類・転回位置）を判定して表示する

### DIFF
--- a/harmony_check.go
+++ b/harmony_check.go
@@ -395,14 +395,19 @@ func harmonyReport(s *smf.SMF, path string) (string, bool) {
 	}
 
 	var b strings.Builder
+	var templates []chordTemplate
 	if hasKey {
 		fmt.Fprintf(&b, "調: %s（ファイル名から）\n", key)
+		templates = chordTemplates(key)
 	} else {
-		b.WriteString("注意: ファイル名から調を読み取れず。増音程・減音程・対斜の検査はスキップし、綴りはフラット表記で代用。\n")
+		b.WriteString("注意: ファイル名から調を読み取れず。和音記号の判定と増音程・減音程・対斜の検査はスキップし、綴りはフラット表記で代用。\n")
 	}
 	fmt.Fprintf(&b, "%d 和音を検査:\n", len(ch.chords))
 	for _, c := range ch.chords {
 		fmt.Fprintf(&b, "  %s ", ch.pos(c.beat))
+		if hasKey {
+			fmt.Fprintf(&b, " %s", chordSymbol(c.notes, templates))
+		}
 		for i, n := range c.notes {
 			fmt.Fprintf(&b, " %s:%s", voiceNames[i], noteName(n, table))
 		}

--- a/harmony_chord.go
+++ b/harmony_chord.go
@@ -1,0 +1,195 @@
+package main
+
+// 和音記号（度数・種類・転回位置）の判定。
+//
+// 調の音階（durは長音階、mollは和声的短音階）上の三度堆積から候補テンプレートを
+// 作り、実施4音のピッチクラス集合と照合する。完全一致を最優先とし、第5音省略形も
+// 許容する（表示には出さない）。VIIの三和音・七の和音は芸大和声の慣例に従い
+// V7・V9の根音省略形として扱う。借用和音は V調（属音を主音とする同モードの調）の
+// V・V7・V9系のみを対象とする。
+
+// 和音構成音の役割。値は転回位置の番号（0=基本位置の基準となる根音）を兼ねる。
+const (
+	roleRoot = iota
+	roleThird
+	roleFifth
+	roleSeventh
+	roleNinth
+)
+
+var inversionNames = [5]string{"基本位置", "第1転回位置", "第2転回位置", "第3転回位置", "第4転回位置"}
+
+var degreeNumerals = [7]string{"I", "II", "III", "IV", "V", "VI", "VII"}
+
+// chordTemplate は照合対象となる和音の雛形。
+type chordTemplate struct {
+	label       string      // 例: "I", "V7", "V調のV9"
+	rootOmitted bool        // 根音省略形
+	borrowed    bool        // 借用和音（V調）
+	sizeRank    int         // 0=三和音, 1=七の和音, 2=九の和音
+	degree      int         // 度数（0..6）。優先順位のタイブレーク用
+	pcByRole    map[int]int // 役割 → ピッチクラス（存在する構成音のみ）
+}
+
+// scalePitchClasses は調の音階のピッチクラスを返す（mollは和声的短音階）。
+func scalePitchClasses(key keySignature) [7]int {
+	steps := [6]int{2, 2, 1, 2, 2, 2}
+	if key.mode == "moll" {
+		steps = [6]int{2, 1, 2, 2, 1, 3}
+	}
+	var s [7]int
+	s[0] = mod12(basePitchClass[key.tonic.letter] + key.tonic.acc)
+	for i, st := range steps {
+		s[i+1] = mod12(s[i] + st)
+	}
+	return s
+}
+
+// buildTemplate は音階のdegree度上にnumTones個の三度堆積和音を作る。
+func buildTemplate(scale [7]int, degree, numTones int, label string) chordTemplate {
+	pcs := make(map[int]int, numTones)
+	for r := range numTones {
+		pcs[r] = scale[(degree+2*r)%7]
+	}
+	return chordTemplate{label: label, sizeRank: numTones - 3, degree: degree, pcByRole: pcs}
+}
+
+// omitRoot は根音省略形を作る。
+func omitRoot(t chordTemplate) chordTemplate {
+	pcs := make(map[int]int, len(t.pcByRole)-1)
+	for r, pc := range t.pcByRole {
+		if r != roleRoot {
+			pcs[r] = pc
+		}
+	}
+	t.pcByRole = pcs
+	t.rootOmitted = true
+	return t
+}
+
+// borrowFromDominant はテンプレートをV調（属音を主音とする同モードの調）へ移す。
+func borrowFromDominant(t chordTemplate) chordTemplate {
+	pcs := make(map[int]int, len(t.pcByRole))
+	for r, pc := range t.pcByRole {
+		pcs[r] = mod12(pc + 7)
+	}
+	t.pcByRole = pcs
+	t.label = "V調の" + t.label
+	t.borrowed = true
+	return t
+}
+
+// chordTemplates は調に対する候補和音テンプレートの一覧を作る。
+func chordTemplates(key keySignature) []chordTemplate {
+	scale := scalePitchClasses(key)
+	var ts []chordTemplate
+	for d := range 6 { // I〜VI。VIIの三和音はV7の根音省略形として扱う
+		ts = append(ts, buildTemplate(scale, d, 3, degreeNumerals[d]))
+	}
+	ii7 := buildTemplate(scale, 1, 4, "II7")
+	v7 := buildTemplate(scale, 4, 4, "V7")
+	v9 := buildTemplate(scale, 4, 5, "V9")
+	ts = append(ts, ii7, v7, omitRoot(v7), v9, omitRoot(v9))
+	v := buildTemplate(scale, 4, 3, "V")
+	for _, t := range []chordTemplate{v, v7, omitRoot(v7), v9, omitRoot(v9)} {
+		ts = append(ts, borrowFromDominant(t))
+	}
+	return ts
+}
+
+// chordAnalysis は和音記号の判定結果。
+type chordAnalysis struct {
+	template     chordTemplate
+	fifthOmitted bool
+	bassRole     int // バスが担う構成音の役割。転回位置の番号
+}
+
+func (a chordAnalysis) String() string {
+	inv := inversionNames[a.bassRole]
+	if a.template.rootOmitted {
+		return a.template.label + "(根音省略形・" + inv + ")"
+	}
+	return a.template.label + "(" + inv + ")"
+}
+
+// matchTemplate は実施のピッチクラス集合をテンプレートと照合する。
+// 完全形が一致しなければ第5音省略形も試す。
+func matchTemplate(t chordTemplate, pcSet [12]bool, bassPC int) (chordAnalysis, bool) {
+	match := func(omitFifth bool) (chordAnalysis, bool) {
+		var want [12]bool
+		bassRole := -1
+		for r, pc := range t.pcByRole {
+			if omitFifth && r == roleFifth {
+				continue
+			}
+			want[pc] = true
+			if pc == bassPC {
+				bassRole = r
+			}
+		}
+		if want != pcSet || bassRole < 0 {
+			return chordAnalysis{}, false
+		}
+		return chordAnalysis{template: t, fifthOmitted: omitFifth, bassRole: bassRole}, true
+	}
+	if a, ok := match(false); ok {
+		return a, true
+	}
+	if _, hasFifth := t.pcByRole[roleFifth]; hasFifth {
+		return match(true)
+	}
+	return chordAnalysis{}, false
+}
+
+// betterAnalysis は a が b より妥当な解釈かを返す。
+// 優先順位: 省略が少ない > 固有和音 > 単純な和音 > 低い度数。
+func betterAnalysis(a, b chordAnalysis) bool {
+	ak := [4]int{b2i(a.fifthOmitted), b2i(a.template.borrowed), a.template.sizeRank, a.template.degree}
+	bk := [4]int{b2i(b.fifthOmitted), b2i(b.template.borrowed), b.template.sizeRank, b.template.degree}
+	for i := range ak {
+		if ak[i] != bk[i] {
+			return ak[i] < bk[i]
+		}
+	}
+	return false
+}
+
+// analyzeChord は4音の和音記号を判定する。どの候補にも一致しなければ ok=false。
+func analyzeChord(notes [4]uint8, templates []chordTemplate) (chordAnalysis, bool) {
+	var pcSet [12]bool
+	bass := notes[0]
+	for _, n := range notes {
+		pcSet[n%12] = true
+		if n < bass {
+			bass = n
+		}
+	}
+	var best chordAnalysis
+	found := false
+	for _, t := range templates {
+		a, ok := matchTemplate(t, pcSet, int(bass%12))
+		if !ok {
+			continue
+		}
+		if !found || betterAnalysis(a, best) {
+			best, found = a, true
+		}
+	}
+	return best, found
+}
+
+// chordSymbol は和音記号の表示文字列を返す。判定できない場合は "?"。
+func chordSymbol(notes [4]uint8, templates []chordTemplate) string {
+	a, ok := analyzeChord(notes, templates)
+	if !ok {
+		return "?"
+	}
+	return a.String()
+}
+
+func b2i(b bool) int {
+	if b {
+		return 1
+	}
+	return 0
+}

--- a/harmony_chord_test.go
+++ b/harmony_chord_test.go
@@ -1,0 +1,97 @@
+package main
+
+import (
+	"strings"
+	"testing"
+)
+
+func templatesFor(t *testing.T, filename string) []chordTemplate {
+	t.Helper()
+	key, ok := parseKeyFromFilename(filename)
+	if !ok {
+		t.Fatalf("failed to parse key from %q", filename)
+	}
+	return chordTemplates(key)
+}
+
+func TestChordSymbolCDur(t *testing.T) {
+	ts := templatesFor(t, "c-dur.mid")
+	tests := []struct {
+		name  string
+		notes [4]uint8 // S A T B
+		want  string
+	}{
+		{"I 基本位置", [4]uint8{72, 67, 64, 60}, "I(基本位置)"},                  // C5 G4 E4 C4
+		{"I 第1転回位置", [4]uint8{72, 67, 60, 52}, "I(第1転回位置)"},              // C5 G4 C4 E3
+		{"IV 第1転回位置", [4]uint8{77, 72, 65, 57}, "IV(第1転回位置)"},            // F5 C5 F4 A3
+		{"V 基本位置", [4]uint8{74, 71, 67, 55}, "V(基本位置)"},                  // D5 B4 G4 G3
+		{"V7 基本位置", [4]uint8{77, 71, 62, 55}, "V7(基本位置)"},                // F5 B4 D4 G3
+		{"V7 第5音省略も V7", [4]uint8{77, 71, 67, 55}, "V7(基本位置)"},           // F5 B4 G4 G3
+		{"V7 第3転回位置", [4]uint8{74, 71, 67, 53}, "V7(第3転回位置)"},            // D5 B4 G4 F3
+		{"V7 根音省略形", [4]uint8{74, 65, 62, 59}, "V7(根音省略形・第1転回位置)"},       // D5 F4 D4 B3
+		{"V9 根音省略形", [4]uint8{69, 65, 62, 59}, "V9(根音省略形・第1転回位置)"},       // A4 F4 D4 B3
+		{"II7 基本位置", [4]uint8{72, 69, 65, 50}, "II7(基本位置)"},              // C5 A4 F4 D3
+		{"V調のV7 基本位置", [4]uint8{72, 69, 66, 50}, "V調のV7(基本位置)"},          // C5 A4 F#4 D3
+		{"V調のV9 根音省略形", [4]uint8{76, 72, 69, 54}, "V調のV9(根音省略形・第1転回位置)"}, // E5 C5 A4 F#3
+		{"判定不能", [4]uint8{72, 71, 61, 60}, "?"},                          // C5 B4 C#4 C4
+	}
+	for _, tt := range tests {
+		if got := chordSymbol(tt.notes, ts); got != tt.want {
+			t.Errorf("%s: chordSymbol(%v) = %s, want %s", tt.name, tt.notes, got, tt.want)
+		}
+	}
+}
+
+func TestChordSymbolEsMoll(t *testing.T) {
+	ts := templatesFor(t, "es-moll.mid")
+	tests := []struct {
+		name  string
+		notes [4]uint8 // S A T B
+		want  string
+	}{
+		{"I 基本位置", [4]uint8{75, 70, 66, 51}, "I(基本位置)"},                  // Eb5 Bb4 Gb4 Eb3
+		{"IV 基本位置", [4]uint8{75, 71, 68, 56}, "IV(基本位置)"},                // Eb5 Cb5 Ab4 Ab3
+		{"V 第1転回位置", [4]uint8{70, 65, 62, 50}, "V(第1転回位置)"},              // Bb4 F4 D4 D3
+		{"V9 根音省略形", [4]uint8{74, 65, 59, 44}, "V9(根音省略形・第3転回位置)"},       // D5 F4 Cb4 Ab2
+		{"V調のV9 根音省略形", [4]uint8{72, 69, 66, 51}, "V調のV9(根音省略形・第3転回位置)"}, // C5 A4 Gb4 Eb3
+	}
+	for _, tt := range tests {
+		if got := chordSymbol(tt.notes, ts); got != tt.want {
+			t.Errorf("%s: chordSymbol(%v) = %s, want %s", tt.name, tt.notes, got, tt.want)
+		}
+	}
+}
+
+func TestChordSymbolAMollDiminishedII(t *testing.T) {
+	// a-moll の II（減三和音）は第1転回位置で頻出
+	ts := templatesFor(t, "a-moll.mid")
+	if got := chordSymbol([4]uint8{71, 65, 62, 50}, ts); got != "II(第1転回位置)" { // B4 F4 D4 D3
+		t.Errorf("chordSymbol = %s, want II(第1転回位置)", got)
+	}
+}
+
+func TestHarmonyReportChordSymbols(t *testing.T) {
+	s := buildChoraleSMF(t,
+		[4]uint8{72, 67, 64, 60}, // I 基本位置
+		[4]uint8{74, 71, 67, 53}, // V7 第3転回位置
+	)
+	report, ok := harmonyReport(s, "c-dur.mid")
+	if !ok {
+		t.Fatal("harmonyReport: not recognized as a 4-voice chorale")
+	}
+	if !strings.Contains(report, "I(基本位置) S:C5") {
+		t.Errorf("report should contain chord symbol for the first chord, got:\n%s", report)
+	}
+	if !strings.Contains(report, "V7(第3転回位置) S:D5") {
+		t.Errorf("report should contain chord symbol for the second chord, got:\n%s", report)
+	}
+
+	// 調が読み取れない場合は和音記号を付けない
+	noKey, ok := harmonyReport(s, "nokey.mid")
+	if !ok {
+		t.Fatal("harmonyReport: not recognized as a 4-voice chorale")
+	}
+	if strings.Contains(noKey, "基本位置") {
+		t.Errorf("report without key should not contain chord symbols, got:\n%s", noKey)
+	}
+}


### PR DESCRIPTION
## Summary
- 調の音階（durは長音階、mollは和声的短音階）上の三度堆積から候補和音テンプレートを生成し、実施4音のピッチクラス集合との照合で和音記号を判定する `harmony_chord.go` を追加
- 候補和音: I〜VIの三和音、II7・V7・V9、V7/V9の根音省略形（VIIの和音はV7/V9根省として扱う）、V調からの借用（V・V7・V7根省・V9根省）。七・九の和音は第5音省略形も許容（表示は変えない）
- 転回位置はバスが担う構成音の役割から決定（根音→基本位置、第3音→第1転回位置、…、第9音→第4転回位置）。根音省略形も省略された根音を基準に数える
- `harmonyReport` の和音一覧に記号を挿入（例: `1小節1拍目  I(基本位置) S:C5 A:G4 T:E4 B:C4`）。調が読み取れない場合は従来どおり記号なしで、注意書きにその旨を追記
- どの候補にも一致しない和音は `?` を表示

実装方針の詳細: https://github.com/nobishino/midiwav/issues/25#issuecomment-4932644491

Closes #25

## Test plan
- [x] `go build ./...`
- [x] `go test ./...`（C-dur / es-moll / a-moll の判定・転回位置・根省・第5音省略・V調のV系・判定不能・レポート組み込みをカバー）
- [x] `gofmt -l .`（出力なし）
- [x] `go vet ./...`

🤖 Generated with [Claude Code](https://claude.com/claude-code)