### PR TITLE
和音一覧にコードネーム表記を追加する

### DIFF
--- a/harmony_check.go
+++ b/harmony_check.go
@@ -408,6 +408,7 @@ func harmonyReport(s *smf.SMF, path string) (string, bool) {
 		if hasKey {
 			fmt.Fprintf(&b, " %s", chordSymbol(c.notes, templates))
 		}
+		fmt.Fprintf(&b, " [%s]", chordName(c.notes, table))
 		for i, n := range c.notes {
 			fmt.Fprintf(&b, " %s:%s", voiceNames[i], noteName(n, table))
 		}

--- a/harmony_chord.go
+++ b/harmony_chord.go
@@ -193,3 +193,77 @@ func b2i(b bool) int {
 	}
 	return 0
 }
+
+// chordQuality はコードネームの種類。intervals は根音からの半音数の集合（0を含む）。
+type chordQuality struct {
+	intervals []int
+	suffix    string
+}
+
+// chordQualities は優先順位順（上ほど優先）。三和音・七の和音の完全形を先に、
+// 第5音省略形と2音の形を後に置く。
+var chordQualities = []chordQuality{
+	{[]int{0, 4, 7}, ""},
+	{[]int{0, 3, 7}, "m"},
+	{[]int{0, 3, 6}, "dim"},
+	{[]int{0, 4, 8}, "aug"},
+	{[]int{0, 4, 7, 10}, "7"},
+	{[]int{0, 3, 7, 10}, "m7"},
+	{[]int{0, 4, 7, 11}, "maj7"},
+	{[]int{0, 3, 7, 11}, "mM7"},
+	{[]int{0, 3, 6, 10}, "m7-5"},
+	{[]int{0, 3, 6, 9}, "dim7"},
+	// 第5音省略の七の和音
+	{[]int{0, 4, 10}, "7"},
+	{[]int{0, 3, 10}, "m7"},
+	{[]int{0, 4, 11}, "maj7"},
+	// 2音
+	{[]int{0, 4}, ""},
+	{[]int{0, 3}, "m"},
+	{[]int{0, 7}, "5"},
+}
+
+// pitchClassName はピッチクラスの音名（オクターブなし）を返す。
+func pitchClassName(pc int, table [12]noteSpelling) string {
+	sp := table[pc]
+	return noteLetters[sp.letter] + accidentalStr[sp.acc]
+}
+
+// chordName は4音のコードネーム（例: "C", "Dm7", "G7/F"）を返す。
+// バスが根音でない場合はスラッシュでバス音を付ける。調に依存せず判定でき、
+// 綴りは渡された表に従う。どの形にも一致しなければ "?"。
+func chordName(notes [4]uint8, table [12]noteSpelling) string {
+	var pcSet [12]bool
+	bass := notes[0]
+	for _, n := range notes {
+		pcSet[n%12] = true
+		if n < bass {
+			bass = n
+		}
+	}
+	bassPC := int(bass % 12)
+	// 根音候補は実施に含まれる音。バスを最優先し、残りはピッチクラス昇順
+	roots := []int{bassPC}
+	for pc := range 12 {
+		if pcSet[pc] && pc != bassPC {
+			roots = append(roots, pc)
+		}
+	}
+	for _, q := range chordQualities {
+		for _, root := range roots {
+			var want [12]bool
+			for _, iv := range q.intervals {
+				want[mod12(root+iv)] = true
+			}
+			if want != pcSet {
+				continue
+			}
+			name := pitchClassName(root, table) + q.suffix
+			if root != bassPC {
+				name += "/" + pitchClassName(bassPC, table)
+			}
+			return name
+		}
+	}
+	return "?"
+}

--- a/harmony_chord_test.go
+++ b/harmony_chord_test.go
@@ -79,19 +79,58 @@ func TestHarmonyReportChordSymbols(t *testing.T) {
 	if !ok {
 		t.Fatal("harmonyReport: not recognized as a 4-voice chorale")
 	}
-	if !strings.Contains(report, "I(基本位置) S:C5") {
-		t.Errorf("report should contain chord symbol for the first chord, got:\n%s", report)
+	if !strings.Contains(report, "I(基本位置) [C] S:C5") {
+		t.Errorf("report should contain chord symbol and name for the first chord, got:\n%s", report)
 	}
-	if !strings.Contains(report, "V7(第3転回位置) S:D5") {
-		t.Errorf("report should contain chord symbol for the second chord, got:\n%s", report)
+	if !strings.Contains(report, "V7(第3転回位置) [G7/F] S:D5") {
+		t.Errorf("report should contain chord symbol and name for the second chord, got:\n%s", report)
 	}
 
-	// 調が読み取れない場合は和音記号を付けない
+	// 調が読み取れない場合は和音記号を付けないが、コードネームは表示する
 	noKey, ok := harmonyReport(s, "nokey.mid")
 	if !ok {
 		t.Fatal("harmonyReport: not recognized as a 4-voice chorale")
 	}
 	if strings.Contains(noKey, "基本位置") {
 		t.Errorf("report without key should not contain chord symbols, got:\n%s", noKey)
+	}
+	if !strings.Contains(noKey, "[C] S:C5") {
+		t.Errorf("report without key should still contain chord names, got:\n%s", noKey)
+	}
+}
+
+func TestChordName(t *testing.T) {
+	cdur, _ := parseKeyFromFilename("c-dur.mid")
+	cdurTable := buildSpellingTable(cdur)
+	amoll, _ := parseKeyFromFilename("a-moll.mid")
+	amollTable := buildSpellingTable(amoll)
+	esmoll, _ := parseKeyFromFilename("es-moll.mid")
+	esmollTable := buildSpellingTable(esmoll)
+
+	tests := []struct {
+		name  string
+		notes [4]uint8 // S A T B
+		table [12]noteSpelling
+		want  string
+	}{
+		{"メジャー", [4]uint8{72, 67, 64, 60}, cdurTable, "C"},           // C5 G4 E4 C4
+		{"メジャー転回", [4]uint8{72, 67, 60, 52}, cdurTable, "C/E"},       // C5 G4 C4 E3
+		{"マイナー7th", [4]uint8{72, 69, 65, 50}, cdurTable, "Dm7"},      // C5 A4 F4 D3
+		{"属7転回", [4]uint8{74, 71, 67, 53}, cdurTable, "G7/F"},        // D5 B4 G4 F3
+		{"属7第5音省略", [4]uint8{77, 71, 67, 55}, cdurTable, "G7"},       // F5 B4 G4 G3
+		{"ディミニッシュ", [4]uint8{74, 65, 62, 59}, cdurTable, "Bdim"},     // D5 F4 D4 B3
+		{"ハーフディミニッシュ", [4]uint8{69, 65, 62, 59}, cdurTable, "Bm7-5"}, // A4 F4 D4 B3
+		{"メジャー7th", [4]uint8{71, 67, 64, 60}, cdurTable, "Cmaj7"},    // B4 G4 E4 C4
+		{"dim7", [4]uint8{77, 71, 62, 56}, amollTable, "G#dim7"},     // F5 B4 D4 G#3
+		{"オーギュメント", [4]uint8{71, 67, 63, 51}, esmollTable, "Ebaug"},  // Cb5 G4 Eb4 Eb3
+		{"フラット綴り", [4]uint8{75, 70, 66, 51}, esmollTable, "Ebm"},     // Eb5 Bb4 Gb4 Eb3
+		{"パワーコード", [4]uint8{72, 67, 60, 48}, cdurTable, "C5"},        // C5 G4 C4 C3
+		{"3度のみ", [4]uint8{76, 72, 64, 48}, cdurTable, "C"},           // E5 C5 E4 C3
+		{"ユニゾンは判定不能", [4]uint8{72, 60, 60, 48}, cdurTable, "?"},      // C5 C4 C4 C3
+	}
+	for _, tt := range tests {
+		if got := chordName(tt.notes, tt.table); got != tt.want {
+			t.Errorf("%s: chordName(%v) = %s, want %s", tt.name, tt.notes, got, tt.want)
+		}
 	}
 }


### PR DESCRIPTION
## Summary
- 和音一覧の各行に `[C]`, `[Dm7]`, `[G7/F]` のようにコードネームを表示する `chordName` を追加（`harmony_chord.go`）
- 記法は C, G7, Dm7, Fmaj7 スタイル。バスが根音でない転回形は `G7/F` のようにスラッシュでバス音を付ける
- 対応する形: 三和音（メジャー・m・dim・aug）、七の和音（7・m7・maj7・mM7・m7-5・dim7）、第5音省略の七の和音、2音（長3度・短3度・完全5度）。aug・dim7のような対称和音はバスを根音として解釈
- コードネームは調に依存しないため、調が読み取れないファイルでも表示（綴りは従来どおりフラット表記で代用）。#26 の和音記号が `?` になる和音でも手がかりが得られる
- どの形にも一致しない場合は `?` を表示

出力例:
```
調: C-dur（ファイル名から）
4 和音を検査:
  1小節1拍目  I(基本位置) [C] S:C5 A:G4 T:E4 B:C4
  2小節1拍目  II7(基本位置) [Dm7] S:C5 A:A4 T:F4 B:D3
  3小節1拍目  V7(第3転回位置) [G7/F] S:D5 A:B4 T:G4 B:F3
  4小節1拍目  ? [?] S:C5 A:B4 T:C#4 B:C4
```

Closes #27

## Test plan
- [x] `go build ./...`
- [x] `go test ./...`（各コード種別・転回スラッシュ・第5音省略・対称和音・綴り・判定不能・調なしレポートをカバー）
- [x] `gofmt -l .`（出力なし）
- [x] `go vet ./...`

🤖 Generated with [Claude Code](https://claude.com/claude-code)