### PR TITLE
WAV正規化で負のピークを考慮する

### DIFF
--- a/midi_player.go
+++ b/midi_player.go
@@ -101,8 +101,8 @@ func summarizeSamples(sampleTracks [][]float64) []int16 {
 			}
 		}
 		sums[i] = sum
-		if sums[i] > maxDeviation {
-			maxDeviation = sums[i]
+		if math.Abs(sums[i]) > maxDeviation {
+			maxDeviation = math.Abs(sums[i])
 		}
 	}
 	return normalizeToInt16(sums, maxDeviation)
@@ -110,6 +110,10 @@ func summarizeSamples(sampleTracks [][]float64) []int16 {
 
 func normalizeToInt16(samples []float64, maxDeviation float64) []int16 {
 	normalized := make([]int16, len(samples))
+	if maxDeviation == 0 {
+		// 全サンプルが無音。0除算（NaN）を避け、無音のまま返す。
+		return trimSilence(normalized)
+	}
 	for i, v := range samples {
 		normalized[i] = int16((v / maxDeviation) * (1<<15 - 1))
 	}

--- a/summarize_samples_test.go
+++ b/summarize_samples_test.go
@@ -1,0 +1,51 @@
+package main
+
+import (
+	"reflect"
+	"testing"
+)
+
+func TestSummarizeSamples(t *testing.T) {
+	tests := []struct {
+		name   string
+		tracks [][]float64
+		want   []int16
+	}{
+		{
+			// 負のピーク（-2.0）の方が大きい波形。絶対値で正規化されること。
+			name:   "negative peak larger than positive",
+			tracks: [][]float64{{0.5, -2.0, 1.0}},
+			want:   []int16{8191, -32767, 16383},
+		},
+		{
+			name:   "positive peak larger than negative",
+			tracks: [][]float64{{2.0, -1.0}},
+			want:   []int16{32767, -16383},
+		},
+		{
+			// トラック合算後の値で正規化されること
+			name:   "sum across tracks",
+			tracks: [][]float64{{1.0, -1.0}, {1.0, -3.0}},
+			want:   []int16{16383, -32767},
+		},
+		{
+			// 全サンプル無音でも 0 除算（NaN）にならないこと
+			name:   "all silence",
+			tracks: [][]float64{{0, 0, 0}},
+			want:   []int16{},
+		},
+		{
+			name:   "no tracks",
+			tracks: nil,
+			want:   []int16{},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := summarizeSamples(tt.tracks)
+			if !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("summarizeSamples() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
Closes #32

## 概要

`summarizeSamples` の `maxDeviation` が正のピークしか追跡しておらず、負のピークの方が大きい波形では `normalizeToInt16` の `v / maxDeviation` が -1 を下回り、`int16` への変換が範囲外（Goでは実装依存の値）になっていました。絶対値でピークを取るように修正します。

あわせて、全サンプルが無音（`maxDeviation == 0`）の場合に 0 除算で NaN が混入するエッジケースも修正します。

## テスト

- `TestSummarizeSamples` を追加: 負のピークが大きいケース、トラック合算後のピーク、全無音、トラックなしの各ケースを検証
- 既存のゴールデンWAVテストは変化なし（現在の testdata は正のピークが最大のため出力が変わらない）

🤖 Generated with [Claude Code](https://claude.com/claude-code)