### PR TITLE
楽譜出力用の中間表現Scoreを追加する（#43 その1）

### DIFF
--- a/harmony/harmony_check.go
+++ b/harmony/harmony_check.go
@@ -174,8 +174,10 @@ func intervalQuality(n1, n2 uint8, table [12]noteSpelling) (int, int, string) {
 
 // chord は同時に発音される4声の音（S, A, T, B の順）。
 type chord struct {
-	beat  float64 // 曲頭からの拍数（4分音符換算）
-	notes [4]uint8
+	beat     float64 // 曲頭からの拍数（4分音符換算）
+	ticks    int64   // 曲頭からのオンセット（ティック）
+	durTicks int64   // 音価（ティック）。次の和音のオンセットまで（最終和音は小節末まで）の近似
+	notes    [4]uint8
 }
 
 // chorale は4声体とみなしたMIDIから抽出した和音列。
@@ -183,6 +185,9 @@ type chorale struct {
 	chords          []chord
 	beatsPerMeasure float64 // 1小節の拍数（4分音符換算）
 	beatUnit        float64 // 1拍の長さ（4分音符換算）
+	meterNum        int     // 拍子の分子
+	meterDenom      int     // 拍子の分母
+	ticksPerQuarter int     // 4分音符あたりのティック数
 }
 
 func (c *chorale) pos(beat float64) string {
@@ -245,16 +250,34 @@ func extractChorale(s *smf.SMF) (*chorale, bool) {
 			notes[i] = n
 		}
 		if all {
-			chords = append(chords, chord{beat: float64(o) / float64(metricTicks), notes: notes})
+			chords = append(chords, chord{beat: float64(o) / float64(metricTicks), ticks: o, notes: notes})
 		}
 	}
 	if len(chords) == 0 {
 		return nil, false
 	}
+
+	// 音価はnote-offを読まず「次の和音のオンセットまで」とする近似。
+	// 最終和音はその小節の末尾まで伸ばす。
+	tpq := int64(metricTicks)
+	measureTicks := tpq * 4 * int64(num) / int64(denom)
+	for i := range chords {
+		if i+1 < len(chords) {
+			chords[i].durTicks = chords[i+1].ticks - chords[i].ticks
+		} else if measureTicks > 0 {
+			chords[i].durTicks = measureTicks - chords[i].ticks%measureTicks
+		} else {
+			chords[i].durTicks = tpq
+		}
+	}
+
 	return &chorale{
 		chords:          chords,
 		beatsPerMeasure: float64(num) * 4 / float64(denom),
 		beatUnit:        4 / float64(denom),
+		meterNum:        int(num),
+		meterDenom:      int(denom),
+		ticksPerQuarter: int(metricTicks),
 	}, true
 }
 
@@ -397,6 +420,7 @@ type Report struct {
 	Key    *Key // 調。不明なら nil
 	Chords []Chord
 	Issues []Issue
+	Score  *Score // 楽譜出力用の中間表現。Chords と同順で対応する
 }
 
 // Analyze は4声体和声の禁則チェックを実行し、分析結果を返す。
@@ -414,7 +438,7 @@ func Analyze(s *smf.SMF, key *Key) (*Report, bool) {
 		templates = chordTemplates(*key)
 	}
 
-	r := &Report{Key: key}
+	r := &Report{Key: key, Score: buildScore(ch, key, table)}
 	for _, c := range ch.chords {
 		chord := Chord{Pos: ch.pos(c.beat), Name: chordName(c.notes, table)}
 		if key != nil {

--- a/harmony/score.go
+++ b/harmony/score.go
@@ -1,0 +1,69 @@
+package harmony
+
+// Score は楽譜出力用の中間表現。MusicXMLなどの楽譜形式への変換に必要な
+// 音高（綴り付き）・音価・調号・拍子を保持する。
+//
+// 音価は「次の和音のオンセットまで」（最終和音は小節末まで）の近似で、
+// 休符や声部ごとの独立したリズムは表現しない（4声が同時に打鍵する
+// ホモフォニックな実施を前提とする）。
+type Score struct {
+	Fifths          int  // 調号の五度圏値（正がシャープ、負がフラット）。調が不明なら0
+	HasKey          bool // 調が判明しているか
+	MeterNum        int  // 拍子の分子
+	MeterDenom      int  // 拍子の分母
+	TicksPerQuarter int  // 4分音符あたりのティック数（音価の単位）
+	Chords          []ScoreChord
+}
+
+// ScoreChord は楽譜上の1和音（4声の同時打鍵）。Report.Chords と同順で対応する。
+type ScoreChord struct {
+	OnsetTicks    int64        // 曲頭からのオンセット（ティック）
+	DurationTicks int64        // 音価（ティック）
+	Notes         [4]ScoreNote // S, A, T, B の順
+}
+
+// ScoreNote は綴り付きの音高。
+type ScoreNote struct {
+	Step   string // 幹音 "C".."B"
+	Alter  int    // 変化（-2〜+2。0は変化なし）
+	Octave int    // 科学的ピッチ表記のオクターブ（C4が中央ハ）
+}
+
+// baseFifths[i] は noteLetters[i] を主音とする長調の調号（五度圏値）。
+var baseFifths = [7]int{0, 2, 4, -1, 1, 3, 5}
+
+// keyFifths は調号のシャープ/フラット数を返す（正がシャープ、負がフラット。
+// 例: C-dur=0, e-moll=1, Es-moll=-6）。
+func keyFifths(key Key) int {
+	f := baseFifths[key.tonic.letter] + 7*key.tonic.acc
+	if key.mode == "moll" {
+		f -= 3
+	}
+	return f
+}
+
+// buildScore はchoraleから楽譜用中間表現を作る。
+func buildScore(ch *chorale, key *Key, table [12]noteSpelling) *Score {
+	sc := &Score{
+		MeterNum:        ch.meterNum,
+		MeterDenom:      ch.meterDenom,
+		TicksPerQuarter: ch.ticksPerQuarter,
+	}
+	if key != nil {
+		sc.HasKey = true
+		sc.Fifths = keyFifths(*key)
+	}
+	for _, c := range ch.chords {
+		var notes [4]ScoreNote
+		for i, n := range c.notes {
+			sp, oct := spellNote(n, table)
+			notes[i] = ScoreNote{Step: noteLetters[sp.letter], Alter: sp.acc, Octave: oct}
+		}
+		sc.Chords = append(sc.Chords, ScoreChord{
+			OnsetTicks:    c.ticks,
+			DurationTicks: c.durTicks,
+			Notes:         notes,
+		})
+	}
+	return sc
+}

--- a/harmony/score_test.go
+++ b/harmony/score_test.go
@@ -1,0 +1,147 @@
+package harmony
+
+import (
+	"testing"
+
+	"gitlab.com/gomidi/midi/v2"
+	"gitlab.com/gomidi/midi/v2/smf"
+)
+
+func TestKeyFifths(t *testing.T) {
+	tests := []struct {
+		filename string
+		want     int
+	}{
+		{"c-dur.mid", 0},
+		{"g-dur.mid", 1},
+		{"f-dur.mid", -1},
+		{"fis-dur.mid", 6},
+		{"b-dur.mid", -2}, // b はドイツ語の B♭
+		{"as-dur.mid", -4},
+		{"a-moll.mid", 0},
+		{"e-moll.mid", 1},
+		{"h-moll.mid", 2},
+		{"cis-moll.mid", 4},
+		{"es-moll.mid", -6},
+	}
+	for _, tt := range tests {
+		key, ok := ParseKeyFromFilename(tt.filename)
+		if !ok {
+			t.Fatalf("failed to parse key from %q", tt.filename)
+		}
+		if got := keyFifths(key); got != tt.want {
+			t.Errorf("keyFifths(%s) = %d, want %d", key, got, tt.want)
+		}
+	}
+}
+
+// buildTimedChoraleSMF は各和音のオンセット間隔（ティック）を指定して
+// SATB 4トラックのSMFを作る。gaps[i] は i番目の和音から次の和音までの間隔。
+func buildTimedChoraleSMF(t *testing.T, gaps []int64, chords [][4]uint8) *smf.SMF {
+	t.Helper()
+	if len(gaps) != len(chords) {
+		t.Fatal("gaps and chords must have the same length")
+	}
+	s := smf.New()
+	for v := range 4 {
+		var tr smf.Track
+		if v == 0 {
+			tr.Add(0, smf.MetaTempo(120))
+			tr.Add(0, smf.MetaMeter(4, 4))
+		}
+		for i, c := range chords {
+			tr.Add(0, midi.NoteOn(0, c[v], 100))
+			tr.Add(uint32(gaps[i]), midi.NoteOff(0, c[v]))
+		}
+		tr.Close(0)
+		if err := s.Add(tr); err != nil {
+			t.Fatal(err)
+		}
+	}
+	return s
+}
+
+func TestAnalyzeScore(t *testing.T) {
+	key, _ := ParseKeyFromFilename("es-moll.mid")
+	s := buildChoraleSMF(t,
+		[4]uint8{75, 70, 66, 51}, // Eb5 Bb4 Gb4 Eb3
+		[4]uint8{74, 70, 65, 46}, // D5 Bb4 F4 Bb2
+	)
+	r, ok := Analyze(s, &key)
+	if !ok {
+		t.Fatal("Analyze: not recognized as a 4-voice chorale")
+	}
+	sc := r.Score
+	if sc == nil {
+		t.Fatal("Report.Score should not be nil")
+	}
+	if !sc.HasKey || sc.Fifths != -6 {
+		t.Errorf("HasKey=%v Fifths=%d, want true, -6", sc.HasKey, sc.Fifths)
+	}
+	if sc.MeterNum != 4 || sc.MeterDenom != 4 {
+		t.Errorf("meter = %d/%d, want 4/4", sc.MeterNum, sc.MeterDenom)
+	}
+	if sc.TicksPerQuarter != 960 {
+		t.Errorf("TicksPerQuarter = %d, want 960", sc.TicksPerQuarter)
+	}
+	if len(sc.Chords) != len(r.Chords) {
+		t.Fatalf("Score.Chords has %d items, want %d (same as Report.Chords)", len(sc.Chords), len(r.Chords))
+	}
+	// 綴り: Eb5 = {E, -1, 5}、Bb2 = {B, -1, 2}
+	if got := sc.Chords[0].Notes[0]; got != (ScoreNote{Step: "E", Alter: -1, Octave: 5}) {
+		t.Errorf("Notes[0] = %+v, want E flat 5", got)
+	}
+	if got := sc.Chords[1].Notes[3]; got != (ScoreNote{Step: "B", Alter: -1, Octave: 2}) {
+		t.Errorf("Notes[3] = %+v, want B flat 2", got)
+	}
+}
+
+func TestScoreDurations(t *testing.T) {
+	// 4/4 (小節=3840ティック)。2分音符2つ + 小節頭の最終和音。
+	s := buildTimedChoraleSMF(t,
+		[]int64{1920, 1920, 960},
+		[][4]uint8{
+			{72, 67, 64, 60},
+			{74, 71, 67, 55},
+			{72, 67, 64, 48},
+		},
+	)
+	r, ok := Analyze(s, nil)
+	if !ok {
+		t.Fatal("Analyze: not recognized as a 4-voice chorale")
+	}
+	sc := r.Score
+	if sc.HasKey {
+		t.Error("HasKey should be false without key")
+	}
+	wantOnsets := []int64{0, 1920, 3840}
+	wantDurs := []int64{1920, 1920, 3840} // 最終和音は小節末まで（小節頭なので全小節分）
+	if len(sc.Chords) != 3 {
+		t.Fatalf("got %d chords, want 3", len(sc.Chords))
+	}
+	for i, c := range sc.Chords {
+		if c.OnsetTicks != wantOnsets[i] || c.DurationTicks != wantDurs[i] {
+			t.Errorf("chord %d: onset=%d dur=%d, want onset=%d dur=%d",
+				i, c.OnsetTicks, c.DurationTicks, wantOnsets[i], wantDurs[i])
+		}
+	}
+}
+
+func TestScoreLastChordMidMeasure(t *testing.T) {
+	// 最終和音が小節の途中（3拍目）から始まる場合、小節末までの長さになる。
+	s := buildTimedChoraleSMF(t,
+		[]int64{1920, 960},
+		[][4]uint8{
+			{72, 67, 64, 60},
+			{74, 71, 67, 55},
+		},
+	)
+	r, ok := Analyze(s, nil)
+	if !ok {
+		t.Fatal("Analyze: not recognized as a 4-voice chorale")
+	}
+	last := r.Score.Chords[1]
+	if last.OnsetTicks != 1920 || last.DurationTicks != 1920 {
+		t.Errorf("last chord: onset=%d dur=%d, want onset=1920 dur=1920", last.OnsetTicks, last.DurationTicks)
+	}
+}


### PR DESCRIPTION
## Summary

#43（五線譜出力・案A）の実装 1/3。MusicXML生成の下準備として、和声分析結果に楽譜化へ必要な情報を持つ中間表現 `Report.Score` を追加します。

- `extractChorale` が音価を保持するようにしました。note-offは読まず**「次の和音のオンセットまで」（最終和音はその小節の末尾まで）の近似**です（issueコメントで合意した方針）。休符や声部ごとの独立したリズムは表現しません
- 拍子の分子/分母と4分音符あたりのティック数（MusicXMLの `divisions` に対応）を保持するようにしました
- 調 → 調号の五度圏値（`fifths`）の計算を追加しました（例: C-dur=0, e-moll=+1, Es-moll=-6）
- `Score` / `ScoreChord` / `ScoreNote` 型を追加しました。綴り付き音高（幹音・変化・オクターブ）と音価（ティック単位の整数、丸め誤差なし）を持ち、`Report.Chords` と同順で対応します

後続PR: (2/3) MusicXML生成、(3/3) 外部レンダラ呼び出し＋config＋Discord添付

Refs #43

## Test plan
- [x] `go test ./...`（fifths計算・音価の近似・最終和音の小節末までの延長・綴りの保持をカバー）
- [x] `gofmt -l .`（出力なし）/ `go vet ./...`
- [x] 既存のgoldenテスト・レポート出力に変更なし

🤖 Generated with [Claude Code](https://claude.com/claude-code)