### PR TITLE
楽譜出力に臨時記号（accidental）を反映する

### DIFF
--- a/harmony/musicxml.go
+++ b/harmony/musicxml.go
@@ -73,19 +73,20 @@ type mxlDirection struct {
 }
 
 // mxlNote の要素順はMusicXMLのDTDに従う:
-// rest/pitch, duration, tie, voice, type, dot, stem, staff, notations
+// rest/pitch, duration, tie, voice, type, dot, accidental, stem, staff, notations
 type mxlNote struct {
-	XMLName   xml.Name      `xml:"note"`
-	Rest      *struct{}     `xml:"rest"`
-	Pitch     *mxlPitch     `xml:"pitch"`
-	Duration  int64         `xml:"duration"`
-	Ties      []mxlTie      `xml:"tie"`
-	Voice     int           `xml:"voice"`
-	Type      string        `xml:"type,omitempty"`
-	Dots      []struct{}    `xml:"dot"`
-	Stem      string        `xml:"stem,omitempty"`
-	Staff     int           `xml:"staff"`
-	Notations *mxlNotations `xml:"notations"`
+	XMLName    xml.Name      `xml:"note"`
+	Rest       *struct{}     `xml:"rest"`
+	Pitch      *mxlPitch     `xml:"pitch"`
+	Duration   int64         `xml:"duration"`
+	Ties       []mxlTie      `xml:"tie"`
+	Voice      int           `xml:"voice"`
+	Type       string        `xml:"type,omitempty"`
+	Dots       []struct{}    `xml:"dot"`
+	Accidental string        `xml:"accidental,omitempty"`
+	Stem       string        `xml:"stem,omitempty"`
+	Staff      int           `xml:"staff"`
+	Notations  *mxlNotations `xml:"notations"`
 }
 
 type mxlPitch struct {
@@ -167,6 +168,63 @@ func noteTypeAndDots(dur, tpq int64) (string, int) {
 	return "", 0
 }
 
+var accidentalNames = map[int]string{
+	-2: "flat-flat", -1: "flat", 0: "natural", 1: "sharp", 2: "double-sharp",
+}
+
+// keyAlters は調号が各幹音に与える変化を返す（例: fifths=-6 なら B,E,A,D,G,C が -1）。
+func keyAlters(fifths int) map[string]int {
+	alters := make(map[string]int, 7)
+	sharps := []string{"F", "C", "G", "D", "A", "E", "B"}
+	for i := 0; i < fifths && i < 7; i++ {
+		alters[sharps[i]] = 1
+	}
+	flats := []string{"B", "E", "A", "D", "G", "C", "F"}
+	for i := 0; i < -fifths && i < 7; i++ {
+		alters[flats[i]] = -1
+	}
+	return alters
+}
+
+// noteLine は臨時記号の適用範囲（同一小節内の同じ幹音・同じオクターブ）を表すキー。
+type noteLine struct {
+	step   string
+	octave int
+}
+
+// computeAccidentals は1小節分のセグメント列に対して、表示すべき臨時記号を
+// (セグメント添字, 声部) → 記号名 のマップで返す。臨時記号は五線ごとに
+// 「調号＋その小節内で確定した変化」と食い違う音に付け、同じ幹音・オクターブ
+// にはその小節内で再度付けない。タイの後半には付けない（前の小節から持続する）。
+// セグメント列は時間順である前提（同時刻の音は声部番号順に処理する）。
+func computeAccidentals(msegs []segment, sc *Score, base map[string]int) map[[2]int]string {
+	state := [2]map[noteLine]int{make(map[noteLine]int), make(map[noteLine]int)}
+	result := make(map[[2]int]string)
+	for si, s := range msegs {
+		if s.chordIdx < 0 {
+			continue
+		}
+		for voice := 1; voice <= 4; voice++ {
+			n := sc.Chords[s.chordIdx].Notes[voice-1]
+			staffIdx := 0
+			if voice >= 3 {
+				staffIdx = 1
+			}
+			line := noteLine{step: n.Step, octave: n.Octave}
+			expected, seen := state[staffIdx][line]
+			if !seen {
+				expected = base[n.Step]
+			}
+			if n.Alter == expected || s.tieStop {
+				continue
+			}
+			result[[2]int{si, voice}] = accidentalNames[n.Alter]
+			state[staffIdx][line] = n.Alter
+		}
+	}
+	return result
+}
+
 // 声部（1=S, 2=A, 3=T, 4=B）の五線と符幹の向き。
 func voiceStaffStem(voice int) (staff int, stem string) {
 	staff = 1
@@ -210,9 +268,11 @@ func (r *Report) MusicXML() ([]byte, error) {
 		byMeasure[m] = append(byMeasure[m], s)
 	}
 
+	baseAlters := keyAlters(sc.Fifths)
 	var measures []mxlMeasure
 	for m, msegs := range byMeasure {
 		measure := mxlMeasure{Number: m + 1}
+		accidentals := computeAccidentals(msegs, sc, baseAlters)
 		if m == 0 {
 			attrs := &mxlAttributes{
 				Divisions: sc.TicksPerQuarter,
@@ -237,7 +297,7 @@ func (r *Report) MusicXML() ([]byte, error) {
 				measure.Items = append(measure.Items, &mxlBackup{Duration: measureLen})
 			}
 			staff, stem := voiceStaffStem(voice)
-			for _, s := range msegs {
+			for si, s := range msegs {
 				// 和音記号は最初の声部の、和音が始まる位置にだけ付ける
 				if voice == 1 && s.chordIdx >= 0 && !s.tieStop {
 					if sym := r.Chords[s.chordIdx].Symbol; sym != "" {
@@ -259,6 +319,7 @@ func (r *Report) MusicXML() ([]byte, error) {
 						pitch.Alter = &alter
 					}
 					note.Pitch = pitch
+					note.Accidental = accidentals[[2]int{si, voice}]
 					note.Stem = stem
 					if s.tieStart || s.tieStop {
 						var notations mxlNotations

--- a/harmony/musicxml_test.go
+++ b/harmony/musicxml_test.go
@@ -162,6 +162,83 @@ func TestMusicXMLTieAcrossBarline(t *testing.T) {
 	}
 }
 
+func TestComputeAccidentals(t *testing.T) {
+	esmoll, _ := ParseKeyFromFilename("es-moll.mid")
+	base := keyAlters(keyFifths(esmoll)) // 6♭: B E A D G C が -1
+	if base["D"] != -1 || base["F"] != 0 {
+		t.Fatalf("keyAlters(-6) = %v, want D=-1 F=0", base)
+	}
+
+	sc := &Score{Chords: []ScoreChord{
+		{Notes: [4]ScoreNote{{"D", 0, 5}, {"F", 0, 4}, {"C", -1, 4}, {"A", -1, 2}}},
+		{Notes: [4]ScoreNote{{"D", 0, 5}, {"F", 0, 4}, {"B", -1, 3}, {"E", -1, 3}}},
+	}}
+	segs := []segment{
+		{chordIdx: 0, start: 0, dur: 960},
+		{chordIdx: 1, start: 960, dur: 960},
+	}
+	acc := computeAccidentals(segs, sc, base)
+	// Es-mollで導音D（ナチュラル）には natural が付く
+	if acc[[2]int{0, 1}] != "natural" {
+		t.Errorf("first D5 should get natural, got %q", acc[[2]int{0, 1}])
+	}
+	// 同じ小節内の同じ幹音・オクターブには2度目は付けない
+	if _, ok := acc[[2]int{1, 1}]; ok {
+		t.Error("second D5 in the same measure should not get an accidental")
+	}
+	// 調号どおりの音（Cb, Ab, Bb, Eb）と調号にない幹音のナチュラル（F）には付けない
+	for _, k := range [][2]int{{0, 2}, {0, 3}, {0, 4}, {1, 2}, {1, 3}, {1, 4}} {
+		if a, ok := acc[k]; ok {
+			t.Errorf("note at %v should not get an accidental, got %q", k, a)
+		}
+	}
+
+	// タイの後半には付けない
+	tied := []segment{
+		{chordIdx: 0, start: 0, dur: 960, tieStop: true},
+	}
+	if acc := computeAccidentals(tied, sc, base); len(acc) != 0 {
+		t.Errorf("tie-stop note should not get an accidental, got %v", acc)
+	}
+
+	// 同時刻にSとAが同じ音（ユニゾン）なら片方にだけ付ける
+	unison := &Score{Chords: []ScoreChord{
+		{Notes: [4]ScoreNote{{"D", 0, 5}, {"D", 0, 5}, {"B", -1, 3}, {"G", -1, 2}}},
+	}}
+	acc = computeAccidentals([]segment{{chordIdx: 0, start: 0, dur: 960}}, unison, base)
+	if acc[[2]int{0, 1}] != "natural" {
+		t.Error("unison: S should get the natural")
+	}
+	if _, ok := acc[[2]int{0, 2}]; ok {
+		t.Error("unison: A should not get a duplicate accidental")
+	}
+}
+
+func TestMusicXMLNaturalAccidental(t *testing.T) {
+	// Es-moll の導音D（ナチュラル）に <accidental>natural</accidental> が付く（#49）
+	key, _ := ParseKeyFromFilename("es-moll.mid")
+	s := buildChoraleSMF(t,
+		[4]uint8{74, 65, 59, 44}, // D5 F4 Cb4 Ab2 (V9根省)
+		[4]uint8{75, 70, 66, 51}, // Eb5 Bb4 Gb4 Eb3 (I)
+	)
+	r, ok := Analyze(s, &key)
+	if !ok {
+		t.Fatal("Analyze failed")
+	}
+	data, err := r.MusicXML()
+	if err != nil {
+		t.Fatal(err)
+	}
+	got := string(data)
+	if !strings.Contains(got, "<accidental>natural</accidental>") {
+		t.Errorf("output should contain natural accidental for D5, got:\n%s", got)
+	}
+	// 調号どおりの音には臨時記号を付けない（naturalは1つだけ）
+	if n := strings.Count(got, "<accidental>"); n != 1 {
+		t.Errorf("got %d accidentals, want 1", n)
+	}
+}
+
 // TestMusicXMLGolden は testdata/*.mid のMusicXML出力をゴールデンファイル
 // （<case>.musicxml）と照合する。go test -update で生成・更新できる。
 func TestMusicXMLGolden(t *testing.T) {

--- a/harmony/testdata/aug-second_a-moll.musicxml
+++ b/harmony/testdata/aug-second_a-moll.musicxml
@@ -117,6 +117,7 @@
         <duration>3840</duration>
         <voice>2</voice>
         <type>whole</type>
+        <accidental>sharp</accidental>
         <stem>down</stem>
         <staff>1</staff>
       </note>

--- a/harmony/testdata/fourseventh_es-moll.musicxml
+++ b/harmony/testdata/fourseventh_es-moll.musicxml
@@ -95,6 +95,7 @@
         <duration>960</duration>
         <voice>1</voice>
         <type>half</type>
+        <accidental>natural</accidental>
         <stem>up</stem>
         <staff>1</staff>
       </note>
@@ -319,6 +320,7 @@
         <duration>960</duration>
         <voice>1</voice>
         <type>half</type>
+        <accidental>natural</accidental>
         <stem>up</stem>
         <staff>1</staff>
       </note>
@@ -526,6 +528,7 @@
         <duration>960</duration>
         <voice>1</voice>
         <type>half</type>
+        <accidental>natural</accidental>
         <stem>up</stem>
         <staff>1</staff>
       </note>
@@ -751,6 +754,7 @@
         <duration>1920</duration>
         <voice>1</voice>
         <type>whole</type>
+        <accidental>natural</accidental>
         <stem>up</stem>
         <staff>1</staff>
       </note>
@@ -777,6 +781,7 @@
         <duration>960</duration>
         <voice>2</voice>
         <type>half</type>
+        <accidental>natural</accidental>
         <stem>down</stem>
         <staff>1</staff>
       </note>
@@ -851,6 +856,7 @@
         <duration>960</duration>
         <voice>4</voice>
         <type>half</type>
+        <accidental>natural</accidental>
         <stem>down</stem>
         <staff>2</staff>
       </note>
@@ -918,6 +924,7 @@
         <duration>960</duration>
         <voice>1</voice>
         <type>half</type>
+        <accidental>natural</accidental>
         <stem>up</stem>
         <staff>1</staff>
       </note>
@@ -1142,6 +1149,7 @@
         <duration>1920</duration>
         <voice>1</voice>
         <type>whole</type>
+        <accidental>natural</accidental>
         <stem>up</stem>
         <staff>1</staff>
       </note>
@@ -1168,6 +1176,7 @@
         <duration>960</duration>
         <voice>2</voice>
         <type>half</type>
+        <accidental>natural</accidental>
         <stem>down</stem>
         <staff>1</staff>
       </note>
@@ -1311,6 +1320,7 @@
         <duration>960</duration>
         <voice>1</voice>
         <type>half</type>
+        <accidental>natural</accidental>
         <stem>up</stem>
         <staff>1</staff>
       </note>
@@ -1518,6 +1528,7 @@
         <duration>960</duration>
         <voice>1</voice>
         <type>half</type>
+        <accidental>natural</accidental>
         <stem>up</stem>
         <staff>1</staff>
       </note>


### PR DESCRIPTION
## Summary

Fixes #49（Es-mollの導音DナチュラルがD♭として描画される）。

## 原因

issueの推測どおりMusicXML段階の問題でした。ただし `<pitch>`（実音データ）は正しく、欠けていたのは**表示用の `<accidental>` 要素**です。Verovioは調号から臨時記号を自動導出しないため、調号（6♭のDb）と食い違うDナチュラルが変化記号なしで描画され、見た目上D♭になっていました。`<accidental>natural</accidental>` を手で足すとナチュラルが表示されることをレンダリングで実証してから実装しています。

## 修正

標準的な記譜規則に従って `<accidental>` を出力します:

- 調号（fifths）が各幹音に与える変化を基準とし、それと食い違う音に臨時記号（flat-flat / flat / natural / sharp / double-sharp）を付ける
- 一度臨時記号を付けた幹音・オクターブには**同一小節内では再度付けない**。状態は五線ごとに時間順で管理し、同時刻のユニゾン（SとAが同音など）にも二重に付けない
- **タイの後半には付けない**（臨時記号は前の小節からタイで持続する）

## goldenファイルの差分

- `fourseventh_es-moll.musicxml`: 導音Dへの `natural` ×11
- `aug-second_a-moll.musicxml`: 導音G#への `sharp` ×1
- C-durの2件と `nokey` は差分なし（全音階のみのため）— 修正の副作用がないことの傍証です

修正後のレンダリングでソプラノのDにナチュラル記号が表示されることを目視確認済みです。

## Test plan
- [x] `go test ./...`（調号基準・小節内の再表示抑制・ユニゾン・タイをユニットテストでカバー）
- [x] `gofmt -l .`（出力なし）/ `go vet ./...`
- [x] Verovio 6.2.1 でレンダリングして目視確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)