### PR TITLE
楽譜上の和音記号をコンパクトな表記にする

### DIFF
--- a/harmony/harmony_check.go
+++ b/harmony/harmony_check.go
@@ -409,10 +409,11 @@ func checkSpelled(ch *chorale, table [12]noteSpelling) []Issue {
 
 // Chord は和音一覧の1項目。
 type Chord struct {
-	Pos    string    // 位置（例: "1小節1拍目"）
-	Symbol string    // 和音記号（度数・種類・転回位置）。調が不明の場合は空
-	Name   string    // コードネーム（例: "C", "G7/F"）
-	Notes  [4]string // S, A, T, B の順の音名
+	Pos         string    // 位置（例: "1小節1拍目"）
+	Symbol      string    // 和音記号（度数・種類・転回位置）。調が不明の場合は空
+	ShortSymbol string    // 楽譜表示用の短い和音記号（例: "V₉(r-)"）。調が不明の場合は空
+	Name        string    // コードネーム（例: "C", "G7/F"）
+	Notes       [4]string // S, A, T, B の順の音名
 }
 
 // Report は4声体和声の分析結果。
@@ -442,7 +443,13 @@ func Analyze(s *smf.SMF, key *Key) (*Report, bool) {
 	for _, c := range ch.chords {
 		chord := Chord{Pos: ch.pos(c.beat), Name: chordName(c.notes, table)}
 		if key != nil {
-			chord.Symbol = chordSymbol(c.notes, templates)
+			if a, ok := analyzeChord(c.notes, templates); ok {
+				chord.Symbol = a.String()
+				chord.ShortSymbol = a.ShortString()
+			} else {
+				chord.Symbol = "?"
+				chord.ShortSymbol = "?"
+			}
 		}
 		for i, n := range c.notes {
 			chord.Notes[i] = noteName(n, table)

--- a/harmony/harmony_chord.go
+++ b/harmony/harmony_chord.go
@@ -160,6 +160,28 @@ func (a chordAnalysis) String() string {
 	return a.template.label + "(" + strings.Join(parts, "・") + ")"
 }
 
+var subscriptDigits = strings.NewReplacer("7", "₇", "9", "₉")
+
+// ShortString は楽譜表示用の短い和音記号を返す（#47）。
+// 転回位置は書かない（楽譜ではバス音が見えるため）。7・9は下付き数字とし、
+// 借用の「V調の」は「V-」、根音省略は (r-)、第5音下方変位（増六）は (-5)、
+// 両方に該当する場合は (-5, r-) と表記する。
+func (a chordAnalysis) ShortString() string {
+	label := strings.ReplaceAll(a.template.label, "V調の", "V-")
+	label = subscriptDigits.Replace(label)
+	var mods []string
+	if a.template.augSixth {
+		mods = append(mods, "-5")
+	}
+	if a.template.rootOmitted {
+		mods = append(mods, "r-")
+	}
+	if len(mods) > 0 {
+		label += "(" + strings.Join(mods, ", ") + ")"
+	}
+	return label
+}
+
 // matchTemplate は実施のピッチクラス集合をテンプレートと照合する。
 // 完全形が一致しなければ第5音の省略形も試す。増六の和音は第5音自体が
 // 特徴音（変位音）であり、第9音の有無で別テンプレートを用意しているため

--- a/harmony/harmony_chord_test.go
+++ b/harmony/harmony_chord_test.go
@@ -68,6 +68,44 @@ func TestChordSymbolEsMoll(t *testing.T) {
 	}
 }
 
+// shortSymbol は楽譜用の短い和音記号を返すテストヘルパー。
+func shortSymbol(notes [4]uint8, ts []chordTemplate) string {
+	a, ok := analyzeChord(notes, ts)
+	if !ok {
+		return "?"
+	}
+	return a.ShortString()
+}
+
+func TestChordShortSymbol(t *testing.T) {
+	cdur := templatesFor(t, "c-dur.mid")
+	esmoll := templatesFor(t, "es-moll.mid")
+	tests := []struct {
+		name  string
+		notes [4]uint8 // S A T B
+		ts    []chordTemplate
+		want  string
+	}{
+		{"転回位置は書かない", [4]uint8{72, 67, 60, 52}, cdur, "I"},            // I 第1転回位置
+		{"7は下付き", [4]uint8{74, 71, 67, 53}, cdur, "V₇"},               // V7 第3転回位置
+		{"根音省略は r-", [4]uint8{74, 65, 62, 59}, cdur, "V₇(r-)"},        // V7 根省
+		{"V9根省", [4]uint8{69, 65, 62, 59}, cdur, "V₉(r-)"},            // V9 根省
+		{"II7", [4]uint8{72, 69, 65, 50}, cdur, "II₇"},                // II7
+		{"借用は V-", [4]uint8{74, 69, 66, 50}, cdur, "V-V"},             // V調のV
+		{"借用の七", [4]uint8{72, 69, 66, 50}, cdur, "V-V₇"},              // V調のV7
+		{"借用の九・根省", [4]uint8{76, 72, 69, 54}, cdur, "V-V₉(r-)"},       // V調のV9 根省
+		{"増六(V7型)", [4]uint8{75, 69, 63, 59}, esmoll, "V-V₇(-5, r-)"}, // 増六 第9音なし
+		{"増六(V9型)", [4]uint8{78, 69, 63, 59}, esmoll, "V-V₉(-5, r-)"}, // 増六 第9音あり
+		{"ドリアのIV", [4]uint8{66, 63, 60, 44}, esmoll, "+IV₇"},          // +IV7
+		{"判定不能", [4]uint8{72, 71, 61, 60}, cdur, "?"},                 // 不一致
+	}
+	for _, tt := range tests {
+		if got := shortSymbol(tt.notes, tt.ts); got != tt.want {
+			t.Errorf("%s: shortSymbol(%v) = %s, want %s", tt.name, tt.notes, got, tt.want)
+		}
+	}
+}
+
 func TestChordSymbolAMollDiminishedII(t *testing.T) {
 	// a-moll の II（減三和音）は第1転回位置で頻出
 	ts := templatesFor(t, "a-moll.mid")

--- a/harmony/musicxml.go
+++ b/harmony/musicxml.go
@@ -298,9 +298,10 @@ func (r *Report) MusicXML() ([]byte, error) {
 			}
 			staff, stem := voiceStaffStem(voice)
 			for si, s := range msegs {
-				// 和音記号は最初の声部の、和音が始まる位置にだけ付ける
+				// 和音記号は最初の声部の、和音が始まる位置にだけ付ける。
+				// 楽譜では転回位置などを省いた短い表記を使う（#47）
 				if voice == 1 && s.chordIdx >= 0 && !s.tieStop {
-					if sym := r.Chords[s.chordIdx].Symbol; sym != "" {
+					if sym := r.Chords[s.chordIdx].ShortSymbol; sym != "" {
 						measure.Items = append(measure.Items, &mxlDirection{
 							Placement: "below",
 							Words:     sym,

--- a/harmony/musicxml_test.go
+++ b/harmony/musicxml_test.go
@@ -96,8 +96,8 @@ func TestMusicXMLBasic(t *testing.T) {
 		"<sign>F</sign>",
 		"<step>C</step>",
 		"<type>whole</type>",
-		"<words>I(基本位置)</words>",
-		"<words>V(基本位置)</words>",
+		"<words>I</words>",
+		"<words>V</words>",
 	} {
 		if !strings.Contains(got, want) {
 			t.Errorf("output should contain %s, got:\n%s", want, got)

--- a/harmony/testdata/aug-second_a-moll.musicxml
+++ b/harmony/testdata/aug-second_a-moll.musicxml
@@ -29,7 +29,7 @@
       </attributes>
       <direction placement="below">
         <direction-type>
-          <words>VI(第1転回位置)</words>
+          <words>VI</words>
         </direction-type>
         <staff>2</staff>
       </direction>
@@ -90,7 +90,7 @@
     <measure number="2">
       <direction placement="below">
         <direction-type>
-          <words>V(基本位置)</words>
+          <words>V</words>
         </direction-type>
         <staff>2</staff>
       </direction>

--- a/harmony/testdata/clean_c-dur.musicxml
+++ b/harmony/testdata/clean_c-dur.musicxml
@@ -29,7 +29,7 @@
       </attributes>
       <direction placement="below">
         <direction-type>
-          <words>I(基本位置)</words>
+          <words>I</words>
         </direction-type>
         <staff>2</staff>
       </direction>
@@ -90,7 +90,7 @@
     <measure number="2">
       <direction placement="below">
         <direction-type>
-          <words>V(基本位置)</words>
+          <words>V</words>
         </direction-type>
         <staff>2</staff>
       </direction>

--- a/harmony/testdata/fourseventh_es-moll.musicxml
+++ b/harmony/testdata/fourseventh_es-moll.musicxml
@@ -29,7 +29,7 @@
       </attributes>
       <direction placement="below">
         <direction-type>
-          <words>I(基本位置)</words>
+          <words>I</words>
         </direction-type>
         <staff>2</staff>
       </direction>
@@ -47,7 +47,7 @@
       </note>
       <direction placement="below">
         <direction-type>
-          <words>I(第1転回位置)</words>
+          <words>I</words>
         </direction-type>
         <staff>2</staff>
       </direction>
@@ -65,7 +65,7 @@
       </note>
       <direction placement="below">
         <direction-type>
-          <words>II7(基本位置)</words>
+          <words>II₇</words>
         </direction-type>
         <staff>2</staff>
       </direction>
@@ -83,7 +83,7 @@
       </note>
       <direction placement="below">
         <direction-type>
-          <words>V9(根音省略形・第3転回位置)</words>
+          <words>V₉(r-)</words>
         </direction-type>
         <staff>2</staff>
       </direction>
@@ -254,7 +254,7 @@
     <measure number="2">
       <direction placement="below">
         <direction-type>
-          <words>I(第1転回位置)</words>
+          <words>I</words>
         </direction-type>
         <staff>2</staff>
       </direction>
@@ -272,7 +272,7 @@
       </note>
       <direction placement="below">
         <direction-type>
-          <words>I(基本位置)</words>
+          <words>I</words>
         </direction-type>
         <staff>2</staff>
       </direction>
@@ -290,7 +290,7 @@
       </note>
       <direction placement="below">
         <direction-type>
-          <words>IV(第1転回位置)</words>
+          <words>IV</words>
         </direction-type>
         <staff>2</staff>
       </direction>
@@ -308,7 +308,7 @@
       </note>
       <direction placement="below">
         <direction-type>
-          <words>V9(根音省略形・第3転回位置)</words>
+          <words>V₉(r-)</words>
         </direction-type>
         <staff>2</staff>
       </direction>
@@ -480,7 +480,7 @@
     <measure number="3">
       <direction placement="below">
         <direction-type>
-          <words>I(第1転回位置)</words>
+          <words>I</words>
         </direction-type>
         <staff>2</staff>
       </direction>
@@ -498,7 +498,7 @@
       </note>
       <direction placement="below">
         <direction-type>
-          <words>IV7(第3転回位置)</words>
+          <words>IV₇</words>
         </direction-type>
         <staff>2</staff>
       </direction>
@@ -516,7 +516,7 @@
       </note>
       <direction placement="below">
         <direction-type>
-          <words>V9(根音省略形・第2転回位置)</words>
+          <words>V₉(r-)</words>
         </direction-type>
         <staff>2</staff>
       </direction>
@@ -534,7 +534,7 @@
       </note>
       <direction placement="below">
         <direction-type>
-          <words>I(第1転回位置)</words>
+          <words>I</words>
         </direction-type>
         <staff>2</staff>
       </direction>
@@ -706,7 +706,7 @@
     <measure number="4">
       <direction placement="below">
         <direction-type>
-          <words>II7(第1転回位置)</words>
+          <words>II₇</words>
         </direction-type>
         <staff>2</staff>
       </direction>
@@ -724,7 +724,7 @@
       </note>
       <direction placement="below">
         <direction-type>
-          <words>V調のV7(第1転回位置)</words>
+          <words>V-V₇</words>
         </direction-type>
         <staff>2</staff>
       </direction>
@@ -742,7 +742,7 @@
       </note>
       <direction placement="below">
         <direction-type>
-          <words>V(基本位置)</words>
+          <words>V</words>
         </direction-type>
         <staff>2</staff>
       </direction>
@@ -876,7 +876,7 @@
     <measure number="5">
       <direction placement="below">
         <direction-type>
-          <words>VI(基本位置)</words>
+          <words>VI</words>
         </direction-type>
         <staff>2</staff>
       </direction>
@@ -894,7 +894,7 @@
       </note>
       <direction placement="below">
         <direction-type>
-          <words>II7(基本位置)</words>
+          <words>II₇</words>
         </direction-type>
         <staff>2</staff>
       </direction>
@@ -912,7 +912,7 @@
       </note>
       <direction placement="below">
         <direction-type>
-          <words>V9(根音省略形・第3転回位置)</words>
+          <words>V₉(r-)</words>
         </direction-type>
         <staff>2</staff>
       </direction>
@@ -930,7 +930,7 @@
       </note>
       <direction placement="below">
         <direction-type>
-          <words>I(第1転回位置)</words>
+          <words>I</words>
         </direction-type>
         <staff>2</staff>
       </direction>
@@ -1101,7 +1101,7 @@
     <measure number="6">
       <direction placement="below">
         <direction-type>
-          <words>VI(基本位置)</words>
+          <words>VI</words>
         </direction-type>
         <staff>2</staff>
       </direction>
@@ -1119,7 +1119,7 @@
       </note>
       <direction placement="below">
         <direction-type>
-          <words>V調のV7(増六・根音省略形・第2転回位置)</words>
+          <words>V-V₇(-5, r-)</words>
         </direction-type>
         <staff>2</staff>
       </direction>
@@ -1137,7 +1137,7 @@
       </note>
       <direction placement="below">
         <direction-type>
-          <words>V(基本位置)</words>
+          <words>V</words>
         </direction-type>
         <staff>2</staff>
       </direction>
@@ -1273,7 +1273,7 @@
     <measure number="7">
       <direction placement="below">
         <direction-type>
-          <words>I(基本位置)</words>
+          <words>I</words>
         </direction-type>
         <staff>2</staff>
       </direction>
@@ -1291,7 +1291,7 @@
       </note>
       <direction placement="below">
         <direction-type>
-          <words>II(第1転回位置)</words>
+          <words>II</words>
         </direction-type>
         <staff>2</staff>
       </direction>
@@ -1308,7 +1308,7 @@
       </note>
       <direction placement="below">
         <direction-type>
-          <words>V7(基本位置)</words>
+          <words>V₇</words>
         </direction-type>
         <staff>2</staff>
       </direction>
@@ -1326,7 +1326,7 @@
       </note>
       <direction placement="below">
         <direction-type>
-          <words>VI(基本位置)</words>
+          <words>VI</words>
         </direction-type>
         <staff>2</staff>
       </direction>
@@ -1498,7 +1498,7 @@
     <measure number="8">
       <direction placement="below">
         <direction-type>
-          <words>II7(基本位置)</words>
+          <words>II₇</words>
         </direction-type>
         <staff>2</staff>
       </direction>
@@ -1516,7 +1516,7 @@
       </note>
       <direction placement="below">
         <direction-type>
-          <words>V7(基本位置)</words>
+          <words>V₇</words>
         </direction-type>
         <staff>2</staff>
       </direction>
@@ -1534,7 +1534,7 @@
       </note>
       <direction placement="below">
         <direction-type>
-          <words>I(基本位置)</words>
+          <words>I</words>
         </direction-type>
         <staff>2</staff>
       </direction>

--- a/harmony/testdata/parallel-fifth_c-dur.musicxml
+++ b/harmony/testdata/parallel-fifth_c-dur.musicxml
@@ -29,7 +29,7 @@
       </attributes>
       <direction placement="below">
         <direction-type>
-          <words>IV(基本位置)</words>
+          <words>IV</words>
         </direction-type>
         <staff>2</staff>
       </direction>
@@ -90,7 +90,7 @@
     <measure number="2">
       <direction placement="below">
         <direction-type>
-          <words>V(基本位置)</words>
+          <words>V</words>
         </direction-type>
         <staff>2</staff>
       </direction>


### PR DESCRIPTION
## Summary

Closes #47。[方針コメント](https://github.com/nobishino/midiwav/issues/47#issuecomment-4935923158)のとおり実装しました。

楽譜表示用の短い和音記号 `Chord.ShortSymbol` を導入し、MusicXMLの `<words>` はこちらを使います。**テキストの添削レポートは従来の詳しい表記のまま**です。

短縮規則:
- 転回位置は書かない（楽譜ではバス音が見える）
- 7・9は下付き数字（Unicode ₇/₉。Verovioでの描画は#47の調査で確認済み）
- 借用和音「V調の」→「V-」
- 根音省略 → `(r-)`、第5音下方変位（増六）→ `(-5)`、両方 → `(-5, r-)`

| レポート表記 | 楽譜表記 |
|---|---|
| `I(第1転回位置)` | `I` |
| `V7(第3転回位置)` | `V₇` |
| `V9(根音省略形・第3転回位置)` | `V₉(r-)` |
| `V調のV7(基本位置)` | `V-V₇` |
| `V調のV9(増六・根音省略形・第2転回位置)` | `V-V₉(-5, r-)` |
| `+IV7(基本位置)` | `+IV₇` |

`fourseventh_es-moll` をVerovioでレンダリングし、1拍ごとに和音が変わる密集箇所でも記号の重なりが解消したことを目視確認済みです。下付き数字も正しく描画されています。

## Test plan
- [x] `go test ./...`（短縮規則の全パターンをユニットテストでカバー、goldenファイル更新）
- [x] `gofmt -l .`（出力なし）/ `go vet ./...`
- [x] Verovio 6.2.1 でレンダリングして目視確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)