### PR TITLE
楽譜冒頭のパート名「SATB」を表示しない

### DIFF
--- a/harmony/musicxml.go
+++ b/harmony/musicxml.go
@@ -27,8 +27,15 @@ type mxlPartList struct {
 }
 
 type mxlScorePart struct {
-	ID   string `xml:"id,attr"`
-	Name string `xml:"part-name"`
+	ID   string      `xml:"id,attr"`
+	Name mxlPartName `xml:"part-name"`
+}
+
+// mxlPartName はパート名。part-name はMusicXMLの必須要素だが、楽譜への
+// 表示は不要なため print-object="no" で抑制する（#48）。
+type mxlPartName struct {
+	PrintObject string `xml:"print-object,attr"`
+	Value       string `xml:",chardata"`
 }
 
 type mxlPart struct {
@@ -348,7 +355,7 @@ func (r *Report) MusicXML() ([]byte, error) {
 	doc := mxlScorePartwise{
 		Version: "4.0",
 		PartList: mxlPartList{ScoreParts: []mxlScorePart{
-			{ID: "P1", Name: "SATB"},
+			{ID: "P1", Name: mxlPartName{PrintObject: "no", Value: "SATB"}},
 		}},
 		Parts: []mxlPart{{ID: "P1", Measures: measures}},
 	}

--- a/harmony/musicxml_test.go
+++ b/harmony/musicxml_test.go
@@ -88,6 +88,7 @@ func TestMusicXMLBasic(t *testing.T) {
 	}
 
 	for _, want := range []string{
+		`<part-name print-object="no">SATB</part-name>`,
 		"<fifths>0</fifths>",
 		"<beats>4</beats>",
 		"<beat-type>4</beat-type>",

--- a/harmony/testdata/aug-second_a-moll.musicxml
+++ b/harmony/testdata/aug-second_a-moll.musicxml
@@ -3,7 +3,7 @@
 <score-partwise version="4.0">
   <part-list>
     <score-part id="P1">
-      <part-name>SATB</part-name>
+      <part-name print-object="no">SATB</part-name>
     </score-part>
   </part-list>
   <part id="P1">

--- a/harmony/testdata/clean_c-dur.musicxml
+++ b/harmony/testdata/clean_c-dur.musicxml
@@ -3,7 +3,7 @@
 <score-partwise version="4.0">
   <part-list>
     <score-part id="P1">
-      <part-name>SATB</part-name>
+      <part-name print-object="no">SATB</part-name>
     </score-part>
   </part-list>
   <part id="P1">

--- a/harmony/testdata/fourseventh_es-moll.musicxml
+++ b/harmony/testdata/fourseventh_es-moll.musicxml
@@ -3,7 +3,7 @@
 <score-partwise version="4.0">
   <part-list>
     <score-part id="P1">
-      <part-name>SATB</part-name>
+      <part-name print-object="no">SATB</part-name>
     </score-part>
   </part-list>
   <part id="P1">

--- a/harmony/testdata/nokey.musicxml
+++ b/harmony/testdata/nokey.musicxml
@@ -3,7 +3,7 @@
 <score-partwise version="4.0">
   <part-list>
     <score-part id="P1">
-      <part-name>SATB</part-name>
+      <part-name print-object="no">SATB</part-name>
     </score-part>
   </part-list>
   <part id="P1">

--- a/harmony/testdata/parallel-fifth_c-dur.musicxml
+++ b/harmony/testdata/parallel-fifth_c-dur.musicxml
@@ -3,7 +3,7 @@
 <score-partwise version="4.0">
   <part-list>
     <score-part id="P1">
-      <part-name>SATB</part-name>
+      <part-name print-object="no">SATB</part-name>
     </score-part>
   </part-list>
   <part id="P1">


### PR DESCRIPTION
## Summary

Closes #48。

`part-name` はMusicXMLの必須要素のため削除はできませんが、`print-object="no"` 属性を付けて表示だけを抑制します（#48の調査で確認済みの方法）。

```xml
<part-name print-object="no">SATB</part-name>
```

修正後のMusicXMLをVerovio 6.2.1でレンダリングし、出力SVGに「SATB」が含まれないことを確認済みです。

## Test plan
- [x] `go test ./...`（print-object属性の出力をテストで確認、goldenファイル更新）
- [x] `gofmt -l .`（出力なし）/ `go vet ./...`
- [x] Verovioでレンダリングして「SATB」が表示されないことを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)