### PR TITLE
和声分析のみを実行する check サブコマンドを追加する

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -73,6 +73,13 @@ The application takes a TOML configuration file (see `config.toml.example` and `
 - Each `[[target]]` entry has `dir` (required), `recursive`, and `discord_webhook_url` (optional)
 - The app runs in watch mode, checking every 10 seconds for new/updated MIDI files
 
+There is also a side-effect-free subcommand that runs only the harmony analysis
+(no WAV/score/Discord output) and exits with 0 (clean), 1 (violations), or 2 (error):
+
+```bash
+./midiwav check [-key <german-key>] [-format text|json] file.mid...
+```
+
 ## Project Layout and Architecture
 
 ### Package Structure
@@ -80,6 +87,7 @@ The application takes a TOML configuration file (see `config.toml.example` and `
 .
 ├── .github/workflows/      # ci.yml (tests+fmt+tidy), gorelease.yml, tagpr.yml
 ├── main.go                 # CLI entry point, watch loop, per-file orchestration
+├── check.go                # `check` subcommand: analysis only, text/json output
 ├── config.go               # TOML config loading ([[target]] entries)
 ├── scan_directory.go       # Finds MIDI files whose WAV is missing or stale
 ├── post_discord.go         # Discord webhook posting (multipart upload)

--- a/README.md
+++ b/README.md
@@ -25,13 +25,38 @@ svg2png_path = "rsvg-convert"   # SVG→PNG。brew install librsvg などで導�
 
 ## Running
 
+### 監視モード
+
+設定ファイルの `[[target]]` ディレクトリを10秒ごとに走査し、新しいMIDIに対して
+WAV合成・和声添削・楽譜生成・Discord投稿を行います。
+
 ```sh
 midiwav -config /path/to/config.toml
 ```
 
+### check サブコマンド（分析のみ）
+
+4声体和声の添削だけを1回実行します。監視モードと違い副作用がありません
+（WAV・楽譜・Discord投稿なし）。スクリプトやCI、対話的な添削フローから使う想定です。
+
+```sh
+midiwav check [-key <調>] [-format text|json] <file.mid>...
+```
+
+- 調はファイル名のドイツ語音名（例: `kadai3_es-moll.mid`）から読み取ります。
+  `-key es-moll` のように指定するとファイル名より優先されます。
+- `-format json` は和音記号・コードネーム・SATB音名つきの構造化データを
+  ファイル数によらず配列で出力します（フィールドは追加されることがあります）。
+- 終了コード: `0`=禁則なし、`1`=禁則（⚠）が1件以上、`2`=実行エラー。
+
+```sh
+$ midiwav check kadai10_es-moll.mid            # 添削レポートを表示
+$ midiwav check -format json *.mid | jq '.[].summary'
+```
+
 ## Package Layout
 
-- `.` (main): CLI。ディレクトリ監視・設定・Discord投稿
+- `.` (main): CLI。ディレクトリ監視・設定・Discord投稿・`check` サブコマンド
 - `harmony`: 4声体和声の分析・添削（禁則チェック、和音記号、コードネーム）
 - `synth`: MIDIからの矩形波によるWAV合成
 

--- a/check.go
+++ b/check.go
@@ -1,0 +1,174 @@
+package main
+
+import (
+	"encoding/json"
+	"flag"
+	"fmt"
+	"io"
+
+	"gitlab.com/gomidi/midi/v2/smf"
+
+	"github.com/nobishino/midiwav/harmony"
+)
+
+// runCheck は check サブコマンドを実行する。watch モードと違い副作用を持たず
+// （WAV合成・楽譜生成・Discord投稿を行わず）、4声体和声の分析だけを行って
+// 結果を stdout に書く。
+//
+// 終了コード: 0=禁則なし, 1=禁則(⚠)が1件以上, 2=実行エラー。
+func runCheck(args []string, stdout, stderr io.Writer) int {
+	fs := flag.NewFlagSet("check", flag.ContinueOnError)
+	fs.SetOutput(stderr)
+	keyName := fs.String("key", "", `調のドイツ語音名。ファイル名の規約より優先する（例: "es-moll"）`)
+	format := fs.String("format", "text", `出力形式: "text" または "json"`)
+	fs.Usage = func() {
+		fmt.Fprintln(stderr, "Usage: midiwav check [-key <調>] [-format text|json] <file.mid>...")
+		fs.PrintDefaults()
+	}
+	if err := fs.Parse(args); err != nil {
+		return 2
+	}
+	if fs.NArg() == 0 {
+		fs.Usage()
+		return 2
+	}
+	if *format != "text" && *format != "json" {
+		fmt.Fprintf(stderr, "midiwav check: -format %q は不正です（\"text\" か \"json\"）\n", *format)
+		return 2
+	}
+	var keyOverride *harmony.Key
+	if *keyName != "" {
+		k, ok := harmony.ParseKey(*keyName)
+		if !ok {
+			fmt.Fprintf(stderr, "midiwav check: -key %q は不正です（ドイツ語音名で例: \"es-moll\"）\n", *keyName)
+			return 2
+		}
+		keyOverride = &k
+	}
+
+	code := 0
+	var results []checkResult
+	for _, path := range fs.Args() {
+		report, err := analyzeFile(path, keyOverride)
+		if err != nil {
+			fmt.Fprintf(stderr, "midiwav check: %s: %v\n", path, err)
+			return 2
+		}
+		if countIssues(report, true) > 0 {
+			code = 1
+		}
+		if *format == "json" {
+			results = append(results, newCheckResult(path, report))
+			continue
+		}
+		if fs.NArg() > 1 {
+			fmt.Fprintf(stdout, "=== %s ===\n", path)
+		}
+		fmt.Fprint(stdout, report.Format())
+	}
+	if *format == "json" {
+		enc := json.NewEncoder(stdout)
+		enc.SetIndent("", "  ")
+		enc.SetEscapeHTML(false)
+		if err := enc.Encode(results); err != nil {
+			fmt.Fprintf(stderr, "midiwav check: %v\n", err)
+			return 2
+		}
+	}
+	return code
+}
+
+// analyzeFile はMIDIファイル1つを読み、4声体和声として分析する。
+// keyOverride が nil の場合はファイル名から調を読み取る。
+func analyzeFile(path string, keyOverride *harmony.Key) (*harmony.Report, error) {
+	smfData, err := smf.ReadFile(path)
+	if err != nil {
+		return nil, fmt.Errorf("failed to read MIDI file: %w", err)
+	}
+	key := keyOverride
+	if key == nil {
+		if k, ok := harmony.ParseKeyFromFilename(path); ok {
+			key = &k
+		}
+	}
+	report, ok := harmony.Analyze(smfData, key)
+	if !ok {
+		return nil, fmt.Errorf("not a four-part chorale (音符のあるトラックがちょうど4本必要です)")
+	}
+	return report, nil
+}
+
+func countIssues(r *harmony.Report, warn bool) int {
+	n := 0
+	for _, is := range r.Issues {
+		if is.Warn == warn {
+			n++
+		}
+	}
+	return n
+}
+
+// checkResult は -format json の1ファイル分の出力。トップレベルは
+// ファイル数によらず checkResult の配列として出力される。
+type checkResult struct {
+	File string `json:"file"`
+	// Key は "Eb-moll" のような調名。ファイル名からも -key からも
+	// 調が得られなかった場合は null（このとき綴り依存の検査はスキップされる）。
+	Key     *string      `json:"key"`
+	Chords  []checkChord `json:"chords"`
+	Issues  []checkIssue `json:"issues"`
+	Summary checkSummary `json:"summary"`
+}
+
+type checkChord struct {
+	Pos string `json:"pos"` // 例: "1小節1拍目"
+	// Symbol は和音記号（例: "V₉(根省)の第2転回位置"）。調が不明なら省略。
+	Symbol string     `json:"symbol,omitempty"`
+	Name   string     `json:"name"` // コードネーム（例: "G7/F"）
+	Notes  checkNotes `json:"notes"`
+}
+
+type checkNotes struct {
+	S string `json:"S"`
+	A string `json:"A"`
+	T string `json:"T"`
+	B string `json:"B"`
+}
+
+type checkIssue struct {
+	Level   string `json:"level"` // "warning"(⚠ 禁則) | "info"(ℹ 参考)
+	Message string `json:"message"`
+}
+
+type checkSummary struct {
+	Warnings int `json:"warnings"`
+	Infos    int `json:"infos"`
+}
+
+func newCheckResult(path string, r *harmony.Report) checkResult {
+	res := checkResult{File: path, Chords: []checkChord{}, Issues: []checkIssue{}}
+	if r.Key != nil {
+		s := r.Key.String()
+		res.Key = &s
+	}
+	for _, c := range r.Chords {
+		res.Chords = append(res.Chords, checkChord{
+			Pos:    c.Pos,
+			Symbol: c.Symbol,
+			Name:   c.Name,
+			Notes:  checkNotes{S: c.Notes[0], A: c.Notes[1], T: c.Notes[2], B: c.Notes[3]},
+		})
+	}
+	for _, is := range r.Issues {
+		level := "info"
+		if is.Warn {
+			level = "warning"
+		}
+		res.Issues = append(res.Issues, checkIssue{Level: level, Message: is.Msg})
+	}
+	res.Summary = checkSummary{
+		Warnings: countIssues(r, true),
+		Infos:    countIssues(r, false),
+	}
+	return res
+}

--- a/check_test.go
+++ b/check_test.go
@@ -1,0 +1,137 @@
+package main
+
+import (
+	"bytes"
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// TestRunCheckTextMatchesGolden は check サブコマンドの text 出力が
+// harmony パッケージのゴールデンファイルと一致することを確認する。
+// 終了コードはゴールデンに ⚠ が含まれるかどうかから決まる。
+func TestRunCheckTextMatchesGolden(t *testing.T) {
+	paths, err := filepath.Glob(filepath.Join("harmony", "testdata", "*.mid"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(paths) == 0 {
+		t.Fatal("no MIDI files found in harmony/testdata")
+	}
+	for _, path := range paths {
+		name := strings.TrimSuffix(filepath.Base(path), ".mid")
+		t.Run(name, func(t *testing.T) {
+			golden, err := os.ReadFile(strings.TrimSuffix(path, ".mid") + ".golden.txt")
+			if err != nil {
+				t.Fatal(err)
+			}
+			wantCode := 0
+			if strings.Contains(string(golden), "⚠") {
+				wantCode = 1
+			}
+
+			var stdout, stderr bytes.Buffer
+			code := runCheck([]string{path}, &stdout, &stderr)
+			if code != wantCode {
+				t.Errorf("exit code = %d, want %d (stderr: %s)", code, wantCode, stderr.String())
+			}
+			if stdout.String() != string(golden) {
+				t.Errorf("output differs from golden\n--- got ---\n%s--- want ---\n%s", stdout.String(), golden)
+			}
+		})
+	}
+}
+
+func TestRunCheckJSON(t *testing.T) {
+	path := filepath.Join("harmony", "testdata", "aug-second_a-moll.mid")
+	var stdout, stderr bytes.Buffer
+	code := runCheck([]string{"-format", "json", path}, &stdout, &stderr)
+	if code != 1 {
+		t.Errorf("exit code = %d, want 1 (stderr: %s)", code, stderr.String())
+	}
+
+	var results []checkResult
+	if err := json.Unmarshal(stdout.Bytes(), &results); err != nil {
+		t.Fatalf("output is not valid JSON: %v\n%s", err, stdout.String())
+	}
+	if len(results) != 1 {
+		t.Fatalf("len(results) = %d, want 1", len(results))
+	}
+	r := results[0]
+	if r.File != path {
+		t.Errorf("file = %q, want %q", r.File, path)
+	}
+	if r.Key == nil || *r.Key != "A-moll" {
+		t.Errorf("key = %v, want A-moll", r.Key)
+	}
+	if len(r.Chords) == 0 {
+		t.Error("chords is empty")
+	}
+	for _, c := range r.Chords {
+		if c.Symbol == "" {
+			t.Errorf("chord %s: symbol is empty (key is known)", c.Pos)
+		}
+		if c.Notes.S == "" || c.Notes.B == "" {
+			t.Errorf("chord %s: notes are incomplete: %+v", c.Pos, c.Notes)
+		}
+	}
+	warns := 0
+	for _, is := range r.Issues {
+		switch is.Level {
+		case "warning":
+			warns++
+		case "info":
+		default:
+			t.Errorf("unknown issue level %q", is.Level)
+		}
+	}
+	if warns == 0 {
+		t.Error("want at least 1 warning (増2度)")
+	}
+	if r.Summary.Warnings != warns {
+		t.Errorf("summary.warnings = %d, want %d", r.Summary.Warnings, warns)
+	}
+}
+
+// TestRunCheckKeyOverride は -key が調不明のファイル名より優先されることを確認する。
+func TestRunCheckKeyOverride(t *testing.T) {
+	path := filepath.Join("harmony", "testdata", "nokey.mid")
+
+	var without bytes.Buffer
+	if code := runCheck([]string{path}, &without, &bytes.Buffer{}); code == 2 {
+		t.Fatal("unexpected error without -key")
+	}
+	if !strings.Contains(without.String(), "調を読み取れず") {
+		t.Errorf("output without -key should note missing key:\n%s", without.String())
+	}
+
+	var with bytes.Buffer
+	if code := runCheck([]string{"-key", "C-dur", path}, &with, &bytes.Buffer{}); code == 2 {
+		t.Fatal("unexpected error with -key")
+	}
+	if !strings.Contains(with.String(), "調: C-dur") {
+		t.Errorf("output with -key should report C-dur:\n%s", with.String())
+	}
+}
+
+func TestRunCheckErrors(t *testing.T) {
+	tests := []struct {
+		name string
+		args []string
+	}{
+		{"no args", nil},
+		{"missing file", []string{"no-such-file.mid"}},
+		{"bad format", []string{"-format", "xml", filepath.Join("harmony", "testdata", "nokey.mid")}},
+		{"bad key", []string{"-key", "x-moll", filepath.Join("harmony", "testdata", "nokey.mid")}},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var stdout, stderr bytes.Buffer
+			if code := runCheck(tt.args, &stdout, &stderr); code != 2 {
+				t.Errorf("exit code = %d, want 2", code)
+			}
+		})
+	}
+}

--- a/harmony/harmony_check.go
+++ b/harmony/harmony_check.go
@@ -76,13 +76,28 @@ func (k Key) String() string {
 	return noteLetters[k.tonic.letter] + accidentalStr[k.tonic.acc] + "-" + k.mode
 }
 
-var keyPattern = regexp.MustCompile(`(?:^|[^a-z])([a-h](?:is|es|s)?)[-_ ]?(dur|moll)`)
+const keyFragment = `([a-h](?:is|es|s)?)[-_ ]?(dur|moll)`
+
+var (
+	keyPattern     = regexp.MustCompile(`(?:^|[^a-z])` + keyFragment)
+	keyNamePattern = regexp.MustCompile(`^` + keyFragment + `$`)
+)
 
 // ParseKeyFromFilename はファイル名のドイツ語音名から調を読み取る（例: es-moll.mid）。
 func ParseKeyFromFilename(path string) (Key, bool) {
 	base := filepath.Base(path)
 	stem := strings.ToLower(strings.TrimSuffix(base, filepath.Ext(base)))
-	m := keyPattern.FindStringSubmatch(stem)
+	return parseKeyMatch(keyPattern.FindStringSubmatch(stem))
+}
+
+// ParseKey はドイツ語音名の調名を解釈する（例: "es-moll", "As-dur"）。
+// ParseKeyFromFilename と違い、文字列全体が調名であることを要求する。
+func ParseKey(name string) (Key, bool) {
+	s := strings.ToLower(strings.TrimSpace(name))
+	return parseKeyMatch(keyNamePattern.FindStringSubmatch(s))
+}
+
+func parseKeyMatch(m []string) (Key, bool) {
 	if m == nil {
 		return Key{}, false
 	}

--- a/harmony/harmony_check_test.go
+++ b/harmony/harmony_check_test.go
@@ -35,6 +35,35 @@ func TestParseKeyFromFilename(t *testing.T) {
 	}
 }
 
+func TestParseKey(t *testing.T) {
+	tests := []struct {
+		name string
+		want string
+		ok   bool
+	}{
+		{"es-moll", "Eb-moll", true},
+		{"As-dur", "Ab-dur", true},
+		{"fis_dur", "F#-dur", true},
+		{"C-Dur", "C-dur", true},
+		{" h-moll ", "B-moll", true}, // 前後の空白は無視する
+		{"b-dur", "Bb-dur", true},
+		{"x-moll", "", false},
+		{"課題1_h-moll", "", false}, // 文字列全体が調名であることを要求する
+		{"moll", "", false},
+		{"", "", false},
+	}
+	for _, tt := range tests {
+		key, ok := ParseKey(tt.name)
+		if ok != tt.ok {
+			t.Errorf("ParseKey(%q) ok = %v, want %v", tt.name, ok, tt.ok)
+			continue
+		}
+		if ok && key.String() != tt.want {
+			t.Errorf("ParseKey(%q) = %s, want %s", tt.name, key, tt.want)
+		}
+	}
+}
+
 func TestBuildSpellingTable(t *testing.T) {
 	mustKey := func(name string) Key {
 		t.Helper()

--- a/main.go
+++ b/main.go
@@ -17,6 +17,12 @@ import (
 )
 
 func main() {
+	// サブコマンド: check（分析のみ・副作用なし）。
+	// 第1引数が check 以外の場合は従来どおり watch モードとして動く。
+	if len(os.Args) > 1 && os.Args[1] == "check" {
+		os.Exit(runCheck(os.Args[2:], os.Stdout, os.Stderr))
+	}
+
 	configPath := flag.String("config", "", "Path to TOML configuration file")
 	flag.Parse()
 


### PR DESCRIPTION
## 目的

添削フロー（対話的なレビューやスクリプト・CI）から和声分析を使えるようにする。現状の watch モードは常駐前提で、WAV合成・楽譜生成・Discord投稿が必ず伴うため、「分析結果だけ欲しい」用途に乗らなかった。

## 内容

```sh
midiwav check [-key <調>] [-format text|json] <file.mid>...
```

- **副作用なし**: WAV・MusicXML/PNG・Discord投稿を行わず、4声体和声の分析だけを実行する
- **終了コード**（lint系の慣例）: `0`=禁則なし / `1`=禁則(⚠)が1件以上 / `2`=実行エラー
- **`-format json`**: 和音記号・コードネーム・SATB音名（調文脈の綴り）つきの構造化出力。トップレベルはファイル数によらず配列。フィールドは追加的に拡張する想定
- **`-key`**: ドイツ語音名で調を明示し、ファイル名規約より優先する（`harmony.ParseKey` を新設。ファイル名に調を含められないファイルの救済用）
- text 出力は `Report.Format()` をそのまま使い、golden テストと真実の源を共有
- 既存の `midiwav -config ...` の挙動は不変（第1引数が `check` のときだけサブコマンド動作）

## テスト

- `check_test.go`: text出力が `harmony/testdata/*.golden.txt` と一致すること、JSON出力の構造とsummary整合、`-key` の優先、エラー系（引数なし・不在ファイル・不正フラグ）の終了コード2
- `harmony/harmony_check_test.go`: `TestParseKey` を追加
- `go test ./...` / `gofmt -l .` / `go vet ./...` / `go mod tidy -diff` すべてクリーン

## 動作確認（実データ）

手元の課題MIDIで確認済み:
- `II-24-7_es-dur.mid` → ⚠1件・ℹ1件で exit 1、JSONも整合
- `-key e-moll` の上書き動作、複数ファイル指定、jq連携

## 今後の拡張候補（このPRには含めない）

1. **和音テンプレートに「Ⅴ調のⅤ₉根音省略（減七）」を追加**: 現状 `A–C–Es–Fis` が `?`/`Adim7` になり、綴りが `Gb` に確定しないため増2度の誤警告が残る（`II-24-7_es-dur.mid` の2小節1拍目で再現可能）
2. finding への安定ID付与と、課題ごとの許容記録ファイル（accept file）による ⚠→ℹ 降格
3. `Chord.Pos` の数値版（measure/beat）をJSONに追加
4. `-key` 指定時に text レポートの「（ファイル名から）」の文言が実態と合わない（軽微・JSON には影響なし）

🤖 Generated with [Claude Code](https://claude.com/claude-code)