### PR TITLE
和音記号ではなくコードネームを表示する

### DIFF
--- a/harmony/harmony_check.go
+++ b/harmony/harmony_check.go
@@ -424,11 +424,10 @@ func checkSpelled(ch *chorale, table [12]noteSpelling) []Issue {
 
 // Chord は和音一覧の1項目。
 type Chord struct {
-	Pos         string    // 位置（例: "1小節1拍目"）
-	Symbol      string    // 和音記号（度数・種類・転回位置）。調が不明の場合は空
-	ShortSymbol string    // 楽譜表示用の短い和音記号（例: "V₉(r-)"）。調が不明の場合は空
-	Name        string    // コードネーム（例: "C", "G7/F"）
-	Notes       [4]string // S, A, T, B の順の音名
+	Pos    string    // 位置（例: "1小節1拍目"）
+	Symbol string    // 和音記号（度数・種類・転回位置）。調が不明の場合は空
+	Name   string    // コードネーム（例: "C", "G7/F"）
+	Notes  [4]string // S, A, T, B の順の音名
 }
 
 // Report は4声体和声の分析結果。
@@ -460,10 +459,8 @@ func Analyze(s *smf.SMF, key *Key) (*Report, bool) {
 		if key != nil {
 			if a, ok := analyzeChord(c.notes, templates); ok {
 				chord.Symbol = a.String()
-				chord.ShortSymbol = a.ShortString()
 			} else {
 				chord.Symbol = "?"
-				chord.ShortSymbol = "?"
 			}
 		}
 		for i, n := range c.notes {

--- a/harmony/harmony_chord.go
+++ b/harmony/harmony_chord.go
@@ -160,28 +160,6 @@ func (a chordAnalysis) String() string {
 	return a.template.label + "(" + strings.Join(parts, "・") + ")"
 }
 
-var subscriptDigits = strings.NewReplacer("7", "₇", "9", "₉")
-
-// ShortString は楽譜表示用の短い和音記号を返す（#47）。
-// 転回位置は書かない（楽譜ではバス音が見えるため）。7・9は下付き数字とし、
-// 借用の「V調の」は「V-」、根音省略は (r-)、第5音下方変位（増六）は (-5)、
-// 両方に該当する場合は (-5, r-) と表記する。
-func (a chordAnalysis) ShortString() string {
-	label := strings.ReplaceAll(a.template.label, "V調の", "V-")
-	label = subscriptDigits.Replace(label)
-	var mods []string
-	if a.template.augSixth {
-		mods = append(mods, "-5")
-	}
-	if a.template.rootOmitted {
-		mods = append(mods, "r-")
-	}
-	if len(mods) > 0 {
-		label += "(" + strings.Join(mods, ", ") + ")"
-	}
-	return label
-}
-
 // matchTemplate は実施のピッチクラス集合をテンプレートと照合する。
 // 完全形が一致しなければ第5音の省略形も試す。増六の和音は第5音自体が
 // 特徴音（変位音）であり、第9音の有無で別テンプレートを用意しているため

--- a/harmony/harmony_chord_test.go
+++ b/harmony/harmony_chord_test.go
@@ -68,44 +68,6 @@ func TestChordSymbolEsMoll(t *testing.T) {
 	}
 }
 
-// shortSymbol は楽譜用の短い和音記号を返すテストヘルパー。
-func shortSymbol(notes [4]uint8, ts []chordTemplate) string {
-	a, ok := analyzeChord(notes, ts)
-	if !ok {
-		return "?"
-	}
-	return a.ShortString()
-}
-
-func TestChordShortSymbol(t *testing.T) {
-	cdur := templatesFor(t, "c-dur.mid")
-	esmoll := templatesFor(t, "es-moll.mid")
-	tests := []struct {
-		name  string
-		notes [4]uint8 // S A T B
-		ts    []chordTemplate
-		want  string
-	}{
-		{"転回位置は書かない", [4]uint8{72, 67, 60, 52}, cdur, "I"},            // I 第1転回位置
-		{"7は下付き", [4]uint8{74, 71, 67, 53}, cdur, "V₇"},               // V7 第3転回位置
-		{"根音省略は r-", [4]uint8{74, 65, 62, 59}, cdur, "V₇(r-)"},        // V7 根省
-		{"V9根省", [4]uint8{69, 65, 62, 59}, cdur, "V₉(r-)"},            // V9 根省
-		{"II7", [4]uint8{72, 69, 65, 50}, cdur, "II₇"},                // II7
-		{"借用は V-", [4]uint8{74, 69, 66, 50}, cdur, "V-V"},             // V調のV
-		{"借用の七", [4]uint8{72, 69, 66, 50}, cdur, "V-V₇"},              // V調のV7
-		{"借用の九・根省", [4]uint8{76, 72, 69, 54}, cdur, "V-V₉(r-)"},       // V調のV9 根省
-		{"増六(V7型)", [4]uint8{75, 69, 63, 59}, esmoll, "V-V₇(-5, r-)"}, // 増六 第9音なし
-		{"増六(V9型)", [4]uint8{78, 69, 63, 59}, esmoll, "V-V₉(-5, r-)"}, // 増六 第9音あり
-		{"ドリアのIV", [4]uint8{66, 63, 60, 44}, esmoll, "+IV₇"},          // +IV7
-		{"判定不能", [4]uint8{72, 71, 61, 60}, cdur, "?"},                 // 不一致
-	}
-	for _, tt := range tests {
-		if got := shortSymbol(tt.notes, tt.ts); got != tt.want {
-			t.Errorf("%s: shortSymbol(%v) = %s, want %s", tt.name, tt.notes, got, tt.want)
-		}
-	}
-}
-
 func TestChordSymbolAMollDiminishedII(t *testing.T) {
 	// a-moll の II（減三和音）は第1転回位置で頻出
 	ts := templatesFor(t, "a-moll.mid")

--- a/harmony/musicxml.go
+++ b/harmony/musicxml.go
@@ -75,9 +75,20 @@ type mxlClef struct {
 type mxlDirection struct {
 	XMLName   xml.Name `xml:"direction"`
 	Placement string   `xml:"placement,attr"`
-	Words     string   `xml:"direction-type>words"`
+	Words     mxlWords `xml:"direction-type>words"`
 	Staff     int      `xml:"staff"`
 }
+
+// mxlWords は direction の文字列。default-y で縦位置を固定する
+// （指定しないとVerovioの自動配置によりバス音符の高さに追従してしまう）。
+type mxlWords struct {
+	DefaultY int    `xml:"default-y,attr"`
+	Value    string `xml:",chardata"`
+}
+
+// chordNameY はコードネームの縦位置（ヘ音記号譜の上第1線基準・tenths単位）。
+// バスの最低音 F2 の全音符と重ならない値（#56）。
+const chordNameY = -100
 
 // mxlNote の要素順はMusicXMLのDTDに従う:
 // rest/pitch, duration, tie, voice, type, dot, accidental, stem, staff, notations
@@ -305,16 +316,14 @@ func (r *Report) MusicXML() ([]byte, error) {
 			}
 			staff, stem := voiceStaffStem(voice)
 			for si, s := range msegs {
-				// 和音記号は最初の声部の、和音が始まる位置にだけ付ける。
-				// 楽譜では転回位置などを省いた短い表記を使う（#47）
+				// コードネームは最初の声部の、和音が始まる位置にだけ付ける（#56）。
+				// 調に依存せず判定できるため、調が不明でも表示する
 				if voice == 1 && s.chordIdx >= 0 && !s.tieStop {
-					if sym := r.Chords[s.chordIdx].ShortSymbol; sym != "" {
-						measure.Items = append(measure.Items, &mxlDirection{
-							Placement: "below",
-							Words:     sym,
-							Staff:     2,
-						})
-					}
+					measure.Items = append(measure.Items, &mxlDirection{
+						Placement: "below",
+						Words:     mxlWords{DefaultY: chordNameY, Value: r.Chords[s.chordIdx].Name},
+						Staff:     2,
+					})
 				}
 				note := &mxlNote{Duration: s.dur, Voice: voice, Staff: staff}
 				if s.chordIdx < 0 {

--- a/harmony/musicxml_test.go
+++ b/harmony/musicxml_test.go
@@ -97,8 +97,8 @@ func TestMusicXMLBasic(t *testing.T) {
 		"<sign>F</sign>",
 		"<step>C</step>",
 		"<type>whole</type>",
-		"<words>I</words>",
-		"<words>V</words>",
+		`<words default-y="-100">C</words>`,
+		`<words default-y="-100">G</words>`,
 	} {
 		if !strings.Contains(got, want) {
 			t.Errorf("output should contain %s, got:\n%s", want, got)
@@ -130,8 +130,9 @@ func TestMusicXMLAccidentalAndNoKey(t *testing.T) {
 	if !strings.Contains(got, "<alter>-1</alter>") {
 		t.Errorf("output should contain alter -1 for Eb, got:\n%s", got)
 	}
-	if strings.Contains(got, "<words>") {
-		t.Error("output without key should not contain chord symbols")
+	// コードネームは調に依存しないため、調が不明でも表示する（#56）
+	if !strings.Contains(got, `<words default-y="-100">Cm</words>`) {
+		t.Errorf("output without key should contain chord name Cm, got:\n%s", got)
 	}
 }
 

--- a/harmony/testdata/aug-second_a-moll.musicxml
+++ b/harmony/testdata/aug-second_a-moll.musicxml
@@ -29,7 +29,7 @@
       </attributes>
       <direction placement="below">
         <direction-type>
-          <words>VI</words>
+          <words default-y="-100">F/A</words>
         </direction-type>
         <staff>2</staff>
       </direction>
@@ -90,7 +90,7 @@
     <measure number="2">
       <direction placement="below">
         <direction-type>
-          <words>V</words>
+          <words default-y="-100">E</words>
         </direction-type>
         <staff>2</staff>
       </direction>

--- a/harmony/testdata/clean_c-dur.musicxml
+++ b/harmony/testdata/clean_c-dur.musicxml
@@ -29,7 +29,7 @@
       </attributes>
       <direction placement="below">
         <direction-type>
-          <words>I</words>
+          <words default-y="-100">C</words>
         </direction-type>
         <staff>2</staff>
       </direction>
@@ -90,7 +90,7 @@
     <measure number="2">
       <direction placement="below">
         <direction-type>
-          <words>V</words>
+          <words default-y="-100">G</words>
         </direction-type>
         <staff>2</staff>
       </direction>

--- a/harmony/testdata/fourseventh_es-moll.musicxml
+++ b/harmony/testdata/fourseventh_es-moll.musicxml
@@ -29,7 +29,7 @@
       </attributes>
       <direction placement="below">
         <direction-type>
-          <words>I</words>
+          <words default-y="-100">Ebm</words>
         </direction-type>
         <staff>2</staff>
       </direction>
@@ -47,7 +47,7 @@
       </note>
       <direction placement="below">
         <direction-type>
-          <words>I</words>
+          <words default-y="-100">Ebm/Gb</words>
         </direction-type>
         <staff>2</staff>
       </direction>
@@ -65,7 +65,7 @@
       </note>
       <direction placement="below">
         <direction-type>
-          <words>II₇</words>
+          <words default-y="-100">Fm7-5</words>
         </direction-type>
         <staff>2</staff>
       </direction>
@@ -83,7 +83,7 @@
       </note>
       <direction placement="below">
         <direction-type>
-          <words>V₉(r-)</words>
+          <words default-y="-100">Abdim7</words>
         </direction-type>
         <staff>2</staff>
       </direction>
@@ -254,7 +254,7 @@
     <measure number="2">
       <direction placement="below">
         <direction-type>
-          <words>I</words>
+          <words default-y="-100">Ebm/Gb</words>
         </direction-type>
         <staff>2</staff>
       </direction>
@@ -272,7 +272,7 @@
       </note>
       <direction placement="below">
         <direction-type>
-          <words>I</words>
+          <words default-y="-100">Ebm</words>
         </direction-type>
         <staff>2</staff>
       </direction>
@@ -290,7 +290,7 @@
       </note>
       <direction placement="below">
         <direction-type>
-          <words>IV</words>
+          <words default-y="-100">Abm/Cb</words>
         </direction-type>
         <staff>2</staff>
       </direction>
@@ -308,7 +308,7 @@
       </note>
       <direction placement="below">
         <direction-type>
-          <words>V₉(r-)</words>
+          <words default-y="-100">Abdim7</words>
         </direction-type>
         <staff>2</staff>
       </direction>
@@ -480,7 +480,7 @@
     <measure number="3">
       <direction placement="below">
         <direction-type>
-          <words>I</words>
+          <words default-y="-100">Ebm/Gb</words>
         </direction-type>
         <staff>2</staff>
       </direction>
@@ -498,7 +498,7 @@
       </note>
       <direction placement="below">
         <direction-type>
-          <words>IV₇</words>
+          <words default-y="-100">Abm7/Gb</words>
         </direction-type>
         <staff>2</staff>
       </direction>
@@ -516,7 +516,7 @@
       </note>
       <direction placement="below">
         <direction-type>
-          <words>V₉(r-)</words>
+          <words default-y="-100">Fdim7</words>
         </direction-type>
         <staff>2</staff>
       </direction>
@@ -534,7 +534,7 @@
       </note>
       <direction placement="below">
         <direction-type>
-          <words>I</words>
+          <words default-y="-100">Ebm/Gb</words>
         </direction-type>
         <staff>2</staff>
       </direction>
@@ -706,7 +706,7 @@
     <measure number="4">
       <direction placement="below">
         <direction-type>
-          <words>II₇</words>
+          <words default-y="-100">Fm7-5/Ab</words>
         </direction-type>
         <staff>2</staff>
       </direction>
@@ -724,7 +724,7 @@
       </note>
       <direction placement="below">
         <direction-type>
-          <words>V-V₇</words>
+          <words default-y="-100">F7/A</words>
         </direction-type>
         <staff>2</staff>
       </direction>
@@ -742,7 +742,7 @@
       </note>
       <direction placement="below">
         <direction-type>
-          <words>V</words>
+          <words default-y="-100">Bb</words>
         </direction-type>
         <staff>2</staff>
       </direction>
@@ -876,7 +876,7 @@
     <measure number="5">
       <direction placement="below">
         <direction-type>
-          <words>VI</words>
+          <words default-y="-100">Cb</words>
         </direction-type>
         <staff>2</staff>
       </direction>
@@ -894,7 +894,7 @@
       </note>
       <direction placement="below">
         <direction-type>
-          <words>II₇</words>
+          <words default-y="-100">Fm7-5</words>
         </direction-type>
         <staff>2</staff>
       </direction>
@@ -912,7 +912,7 @@
       </note>
       <direction placement="below">
         <direction-type>
-          <words>V₉(r-)</words>
+          <words default-y="-100">Abdim7</words>
         </direction-type>
         <staff>2</staff>
       </direction>
@@ -930,7 +930,7 @@
       </note>
       <direction placement="below">
         <direction-type>
-          <words>I</words>
+          <words default-y="-100">Ebm/Gb</words>
         </direction-type>
         <staff>2</staff>
       </direction>
@@ -1101,7 +1101,7 @@
     <measure number="6">
       <direction placement="below">
         <direction-type>
-          <words>VI</words>
+          <words default-y="-100">Cb</words>
         </direction-type>
         <staff>2</staff>
       </direction>
@@ -1119,7 +1119,7 @@
       </note>
       <direction placement="below">
         <direction-type>
-          <words>V-V₇(-5, r-)</words>
+          <words default-y="-100">Cb7</words>
         </direction-type>
         <staff>2</staff>
       </direction>
@@ -1137,7 +1137,7 @@
       </note>
       <direction placement="below">
         <direction-type>
-          <words>V</words>
+          <words default-y="-100">Bb</words>
         </direction-type>
         <staff>2</staff>
       </direction>
@@ -1273,7 +1273,7 @@
     <measure number="7">
       <direction placement="below">
         <direction-type>
-          <words>I</words>
+          <words default-y="-100">Ebm</words>
         </direction-type>
         <staff>2</staff>
       </direction>
@@ -1291,7 +1291,7 @@
       </note>
       <direction placement="below">
         <direction-type>
-          <words>II</words>
+          <words default-y="-100">Fdim/Ab</words>
         </direction-type>
         <staff>2</staff>
       </direction>
@@ -1308,7 +1308,7 @@
       </note>
       <direction placement="below">
         <direction-type>
-          <words>V₇</words>
+          <words default-y="-100">Bb7</words>
         </direction-type>
         <staff>2</staff>
       </direction>
@@ -1326,7 +1326,7 @@
       </note>
       <direction placement="below">
         <direction-type>
-          <words>VI</words>
+          <words default-y="-100">Cb</words>
         </direction-type>
         <staff>2</staff>
       </direction>
@@ -1498,7 +1498,7 @@
     <measure number="8">
       <direction placement="below">
         <direction-type>
-          <words>II₇</words>
+          <words default-y="-100">Fm7-5</words>
         </direction-type>
         <staff>2</staff>
       </direction>
@@ -1516,7 +1516,7 @@
       </note>
       <direction placement="below">
         <direction-type>
-          <words>V₇</words>
+          <words default-y="-100">Bb7</words>
         </direction-type>
         <staff>2</staff>
       </direction>
@@ -1534,7 +1534,7 @@
       </note>
       <direction placement="below">
         <direction-type>
-          <words>I</words>
+          <words default-y="-100">Ebm</words>
         </direction-type>
         <staff>2</staff>
       </direction>

--- a/harmony/testdata/nokey.musicxml
+++ b/harmony/testdata/nokey.musicxml
@@ -24,6 +24,12 @@
           <line>4</line>
         </clef>
       </attributes>
+      <direction placement="below">
+        <direction-type>
+          <words default-y="-100">C</words>
+        </direction-type>
+        <staff>2</staff>
+      </direction>
       <note>
         <pitch>
           <step>C</step>
@@ -79,6 +85,12 @@
       </note>
     </measure>
     <measure number="2">
+      <direction placement="below">
+        <direction-type>
+          <words default-y="-100">G</words>
+        </direction-type>
+        <staff>2</staff>
+      </direction>
       <note>
         <pitch>
           <step>B</step>

--- a/harmony/testdata/parallel-fifth_c-dur.musicxml
+++ b/harmony/testdata/parallel-fifth_c-dur.musicxml
@@ -29,7 +29,7 @@
       </attributes>
       <direction placement="below">
         <direction-type>
-          <words>IV</words>
+          <words default-y="-100">F</words>
         </direction-type>
         <staff>2</staff>
       </direction>
@@ -90,7 +90,7 @@
     <measure number="2">
       <direction placement="below">
         <direction-type>
-          <words>V</words>
+          <words default-y="-100">G</words>
         </direction-type>
         <staff>2</staff>
       </direction>

--- a/notation.go
+++ b/notation.go
@@ -19,8 +19,10 @@ import (
 
 // renderSVG は MusicXML を Verovio でSVGに変換する。
 // 全小節が1ページに収まるよう、ページ高さを大きく取って内容に合わせて切り詰める。
+// Verovioは音価だけで水平方向の間隔を決め、コードネーム（direction/words）の
+// 幅を考慮しないため、隣り合う長いコードネームが重ならないよう間隔を広げる（#56）。
 func renderSVG(verovioPath string, musicXML []byte) ([]byte, error) {
-	cmd := exec.Command(verovioPath, "--page-height", "60000", "--adjust-page-height", "-o", "-", "-")
+	cmd := exec.Command(verovioPath, "--spacing-linear", "0.5", "--page-height", "60000", "--adjust-page-height", "-o", "-", "-")
 	cmd.Stdin = bytes.NewReader(musicXML)
 	var out, errBuf bytes.Buffer
 	cmd.Stdout, cmd.Stderr = &out, &errBuf


### PR DESCRIPTION
Closes #56

## 概要

楽譜上の和音記号を芸大和声方式の短縮表記（`V₇(r-)` など）からコードネーム（`C`, `Ebm/Gb`, `Abdim7` など）に変更します。実装方針は #56 のコメントに記載した検討結果のとおりです。

## 変更内容

- **コードネームの表示**: 判定済みの `Chord.Name` を `direction/words` に出力。コードネームは調に依存せず判定できるため、調が不明な場合も表示するようにした
- **縦位置の固定**: `words` に `default-y="-100"` を指定。指定しないとVerovioの自動配置によりバス音符の高さに追従して記号の位置がばらつく（検証: 指定なしでy=3375/3561/3384 → 指定ありで全て3561に固定。バス最低音F2とも重ならない）
- **水平方向の重なり解消**: Verovioは音価だけで間隔を決めコードネームの幅を考慮しないため、隣り合う長い名前（`Ebm/Gb` と `Abdim7` など）が重なる。Verovio呼び出しに `--spacing-linear 0.5` を追加して解消（0.4では最悪ケースの es-moll でまだ僅かに重なることを確認済み）
- **不要コードの削除**: 使用箇所がなくなった `ShortString()`・`subscriptDigits`・`Chord.ShortSymbol` を削除（芸大記号の楽譜表示は別issueで検討。必要になればgit履歴から復元可能）
- **テスト**: `musicxml_test.go` の期待値更新（調不明時は「記号なし」→「コードネームあり」の検証に反転）、`TestChordShortSymbol` 削除、goldenファイル再生成（`go test -update`）

## 検証

- `go test ./...`・`go vet ./...` 成功
- 本番と同一のコマンドライン（Verovio 6.2.1 + rsvg-convert）で再生成後のgolden MusicXMLをレンダリングし、以下を画像で確認:
  - フラット・分数コード多数の es-moll で全コードネームが一定の高さ・重なりなしで表示される
  - 調不明（nokey）でもコードネームが表示される

なお MusicXML の `<harmony>` 要素を使う案は、Verovioが♭をSMuFLフォントの埋め込みwoff2で出力し rsvg-convert が解釈できず文字化けするため不採用としました（詳細は #56 のコメント参照）。

🤖 Generated with [Claude Code](https://claude.com/claude-code)