### PR TITLE
楽譜上のコードネームを斜体でなく直立体で表示する

### DIFF
--- a/harmony/musicxml.go
+++ b/harmony/musicxml.go
@@ -81,9 +81,11 @@ type mxlDirection struct {
 
 // mxlWords は direction の文字列。default-y で縦位置を固定する
 // （指定しないとVerovioの自動配置によりバス音符の高さに追従してしまう）。
+// font-style を指定しないとVerovioは斜体で描画する。
 type mxlWords struct {
-	DefaultY int    `xml:"default-y,attr"`
-	Value    string `xml:",chardata"`
+	DefaultY  int    `xml:"default-y,attr"`
+	FontStyle string `xml:"font-style,attr"`
+	Value     string `xml:",chardata"`
 }
 
 // chordNameY はコードネームの縦位置（ヘ音記号譜の上第1線基準・tenths単位）。
@@ -321,7 +323,7 @@ func (r *Report) MusicXML() ([]byte, error) {
 				if voice == 1 && s.chordIdx >= 0 && !s.tieStop {
 					measure.Items = append(measure.Items, &mxlDirection{
 						Placement: "below",
-						Words:     mxlWords{DefaultY: chordNameY, Value: r.Chords[s.chordIdx].Name},
+						Words:     mxlWords{DefaultY: chordNameY, FontStyle: "normal", Value: r.Chords[s.chordIdx].Name},
 						Staff:     2,
 					})
 				}

--- a/harmony/musicxml_test.go
+++ b/harmony/musicxml_test.go
@@ -97,8 +97,8 @@ func TestMusicXMLBasic(t *testing.T) {
 		"<sign>F</sign>",
 		"<step>C</step>",
 		"<type>whole</type>",
-		`<words default-y="-100">C</words>`,
-		`<words default-y="-100">G</words>`,
+		`<words default-y="-100" font-style="normal">C</words>`,
+		`<words default-y="-100" font-style="normal">G</words>`,
 	} {
 		if !strings.Contains(got, want) {
 			t.Errorf("output should contain %s, got:\n%s", want, got)
@@ -131,7 +131,7 @@ func TestMusicXMLAccidentalAndNoKey(t *testing.T) {
 		t.Errorf("output should contain alter -1 for Eb, got:\n%s", got)
 	}
 	// コードネームは調に依存しないため、調が不明でも表示する（#56）
-	if !strings.Contains(got, `<words default-y="-100">Cm</words>`) {
+	if !strings.Contains(got, `<words default-y="-100" font-style="normal">Cm</words>`) {
 		t.Errorf("output without key should contain chord name Cm, got:\n%s", got)
 	}
 }

--- a/harmony/testdata/aug-second_a-moll.musicxml
+++ b/harmony/testdata/aug-second_a-moll.musicxml
@@ -29,7 +29,7 @@
       </attributes>
       <direction placement="below">
         <direction-type>
-          <words default-y="-100">F/A</words>
+          <words default-y="-100" font-style="normal">F/A</words>
         </direction-type>
         <staff>2</staff>
       </direction>
@@ -90,7 +90,7 @@
     <measure number="2">
       <direction placement="below">
         <direction-type>
-          <words default-y="-100">E</words>
+          <words default-y="-100" font-style="normal">E</words>
         </direction-type>
         <staff>2</staff>
       </direction>

--- a/harmony/testdata/clean_c-dur.musicxml
+++ b/harmony/testdata/clean_c-dur.musicxml
@@ -29,7 +29,7 @@
       </attributes>
       <direction placement="below">
         <direction-type>
-          <words default-y="-100">C</words>
+          <words default-y="-100" font-style="normal">C</words>
         </direction-type>
         <staff>2</staff>
       </direction>
@@ -90,7 +90,7 @@
     <measure number="2">
       <direction placement="below">
         <direction-type>
-          <words default-y="-100">G</words>
+          <words default-y="-100" font-style="normal">G</words>
         </direction-type>
         <staff>2</staff>
       </direction>

--- a/harmony/testdata/fourseventh_es-moll.musicxml
+++ b/harmony/testdata/fourseventh_es-moll.musicxml
@@ -29,7 +29,7 @@
       </attributes>
       <direction placement="below">
         <direction-type>
-          <words default-y="-100">Ebm</words>
+          <words default-y="-100" font-style="normal">Ebm</words>
         </direction-type>
         <staff>2</staff>
       </direction>
@@ -47,7 +47,7 @@
       </note>
       <direction placement="below">
         <direction-type>
-          <words default-y="-100">Ebm/Gb</words>
+          <words default-y="-100" font-style="normal">Ebm/Gb</words>
         </direction-type>
         <staff>2</staff>
       </direction>
@@ -65,7 +65,7 @@
       </note>
       <direction placement="below">
         <direction-type>
-          <words default-y="-100">Fm7-5</words>
+          <words default-y="-100" font-style="normal">Fm7-5</words>
         </direction-type>
         <staff>2</staff>
       </direction>
@@ -83,7 +83,7 @@
       </note>
       <direction placement="below">
         <direction-type>
-          <words default-y="-100">Abdim7</words>
+          <words default-y="-100" font-style="normal">Abdim7</words>
         </direction-type>
         <staff>2</staff>
       </direction>
@@ -254,7 +254,7 @@
     <measure number="2">
       <direction placement="below">
         <direction-type>
-          <words default-y="-100">Ebm/Gb</words>
+          <words default-y="-100" font-style="normal">Ebm/Gb</words>
         </direction-type>
         <staff>2</staff>
       </direction>
@@ -272,7 +272,7 @@
       </note>
       <direction placement="below">
         <direction-type>
-          <words default-y="-100">Ebm</words>
+          <words default-y="-100" font-style="normal">Ebm</words>
         </direction-type>
         <staff>2</staff>
       </direction>
@@ -290,7 +290,7 @@
       </note>
       <direction placement="below">
         <direction-type>
-          <words default-y="-100">Abm/Cb</words>
+          <words default-y="-100" font-style="normal">Abm/Cb</words>
         </direction-type>
         <staff>2</staff>
       </direction>
@@ -308,7 +308,7 @@
       </note>
       <direction placement="below">
         <direction-type>
-          <words default-y="-100">Abdim7</words>
+          <words default-y="-100" font-style="normal">Abdim7</words>
         </direction-type>
         <staff>2</staff>
       </direction>
@@ -480,7 +480,7 @@
     <measure number="3">
       <direction placement="below">
         <direction-type>
-          <words default-y="-100">Ebm/Gb</words>
+          <words default-y="-100" font-style="normal">Ebm/Gb</words>
         </direction-type>
         <staff>2</staff>
       </direction>
@@ -498,7 +498,7 @@
       </note>
       <direction placement="below">
         <direction-type>
-          <words default-y="-100">Abm7/Gb</words>
+          <words default-y="-100" font-style="normal">Abm7/Gb</words>
         </direction-type>
         <staff>2</staff>
       </direction>
@@ -516,7 +516,7 @@
       </note>
       <direction placement="below">
         <direction-type>
-          <words default-y="-100">Fdim7</words>
+          <words default-y="-100" font-style="normal">Fdim7</words>
         </direction-type>
         <staff>2</staff>
       </direction>
@@ -534,7 +534,7 @@
       </note>
       <direction placement="below">
         <direction-type>
-          <words default-y="-100">Ebm/Gb</words>
+          <words default-y="-100" font-style="normal">Ebm/Gb</words>
         </direction-type>
         <staff>2</staff>
       </direction>
@@ -706,7 +706,7 @@
     <measure number="4">
       <direction placement="below">
         <direction-type>
-          <words default-y="-100">Fm7-5/Ab</words>
+          <words default-y="-100" font-style="normal">Fm7-5/Ab</words>
         </direction-type>
         <staff>2</staff>
       </direction>
@@ -724,7 +724,7 @@
       </note>
       <direction placement="below">
         <direction-type>
-          <words default-y="-100">F7/A</words>
+          <words default-y="-100" font-style="normal">F7/A</words>
         </direction-type>
         <staff>2</staff>
       </direction>
@@ -742,7 +742,7 @@
       </note>
       <direction placement="below">
         <direction-type>
-          <words default-y="-100">Bb</words>
+          <words default-y="-100" font-style="normal">Bb</words>
         </direction-type>
         <staff>2</staff>
       </direction>
@@ -876,7 +876,7 @@
     <measure number="5">
       <direction placement="below">
         <direction-type>
-          <words default-y="-100">Cb</words>
+          <words default-y="-100" font-style="normal">Cb</words>
         </direction-type>
         <staff>2</staff>
       </direction>
@@ -894,7 +894,7 @@
       </note>
       <direction placement="below">
         <direction-type>
-          <words default-y="-100">Fm7-5</words>
+          <words default-y="-100" font-style="normal">Fm7-5</words>
         </direction-type>
         <staff>2</staff>
       </direction>
@@ -912,7 +912,7 @@
       </note>
       <direction placement="below">
         <direction-type>
-          <words default-y="-100">Abdim7</words>
+          <words default-y="-100" font-style="normal">Abdim7</words>
         </direction-type>
         <staff>2</staff>
       </direction>
@@ -930,7 +930,7 @@
       </note>
       <direction placement="below">
         <direction-type>
-          <words default-y="-100">Ebm/Gb</words>
+          <words default-y="-100" font-style="normal">Ebm/Gb</words>
         </direction-type>
         <staff>2</staff>
       </direction>
@@ -1101,7 +1101,7 @@
     <measure number="6">
       <direction placement="below">
         <direction-type>
-          <words default-y="-100">Cb</words>
+          <words default-y="-100" font-style="normal">Cb</words>
         </direction-type>
         <staff>2</staff>
       </direction>
@@ -1119,7 +1119,7 @@
       </note>
       <direction placement="below">
         <direction-type>
-          <words default-y="-100">Cb7</words>
+          <words default-y="-100" font-style="normal">Cb7</words>
         </direction-type>
         <staff>2</staff>
       </direction>
@@ -1137,7 +1137,7 @@
       </note>
       <direction placement="below">
         <direction-type>
-          <words default-y="-100">Bb</words>
+          <words default-y="-100" font-style="normal">Bb</words>
         </direction-type>
         <staff>2</staff>
       </direction>
@@ -1273,7 +1273,7 @@
     <measure number="7">
       <direction placement="below">
         <direction-type>
-          <words default-y="-100">Ebm</words>
+          <words default-y="-100" font-style="normal">Ebm</words>
         </direction-type>
         <staff>2</staff>
       </direction>
@@ -1291,7 +1291,7 @@
       </note>
       <direction placement="below">
         <direction-type>
-          <words default-y="-100">Fdim/Ab</words>
+          <words default-y="-100" font-style="normal">Fdim/Ab</words>
         </direction-type>
         <staff>2</staff>
       </direction>
@@ -1308,7 +1308,7 @@
       </note>
       <direction placement="below">
         <direction-type>
-          <words default-y="-100">Bb7</words>
+          <words default-y="-100" font-style="normal">Bb7</words>
         </direction-type>
         <staff>2</staff>
       </direction>
@@ -1326,7 +1326,7 @@
       </note>
       <direction placement="below">
         <direction-type>
-          <words default-y="-100">Cb</words>
+          <words default-y="-100" font-style="normal">Cb</words>
         </direction-type>
         <staff>2</staff>
       </direction>
@@ -1498,7 +1498,7 @@
     <measure number="8">
       <direction placement="below">
         <direction-type>
-          <words default-y="-100">Fm7-5</words>
+          <words default-y="-100" font-style="normal">Fm7-5</words>
         </direction-type>
         <staff>2</staff>
       </direction>
@@ -1516,7 +1516,7 @@
       </note>
       <direction placement="below">
         <direction-type>
-          <words default-y="-100">Bb7</words>
+          <words default-y="-100" font-style="normal">Bb7</words>
         </direction-type>
         <staff>2</staff>
       </direction>
@@ -1534,7 +1534,7 @@
       </note>
       <direction placement="below">
         <direction-type>
-          <words default-y="-100">Ebm</words>
+          <words default-y="-100" font-style="normal">Ebm</words>
         </direction-type>
         <staff>2</staff>
       </direction>

--- a/harmony/testdata/nokey.musicxml
+++ b/harmony/testdata/nokey.musicxml
@@ -26,7 +26,7 @@
       </attributes>
       <direction placement="below">
         <direction-type>
-          <words default-y="-100">C</words>
+          <words default-y="-100" font-style="normal">C</words>
         </direction-type>
         <staff>2</staff>
       </direction>
@@ -87,7 +87,7 @@
     <measure number="2">
       <direction placement="below">
         <direction-type>
-          <words default-y="-100">G</words>
+          <words default-y="-100" font-style="normal">G</words>
         </direction-type>
         <staff>2</staff>
       </direction>

--- a/harmony/testdata/parallel-fifth_c-dur.musicxml
+++ b/harmony/testdata/parallel-fifth_c-dur.musicxml
@@ -29,7 +29,7 @@
       </attributes>
       <direction placement="below">
         <direction-type>
-          <words default-y="-100">F</words>
+          <words default-y="-100" font-style="normal">F</words>
         </direction-type>
         <staff>2</staff>
       </direction>
@@ -90,7 +90,7 @@
     <measure number="2">
       <direction placement="below">
         <direction-type>
-          <words default-y="-100">G</words>
+          <words default-y="-100" font-style="normal">G</words>
         </direction-type>
         <staff>2</staff>
       </direction>


### PR DESCRIPTION
#56 のフォローアップです。

## 概要

楽譜上のコードネームが斜体で表示されていたのを、通常の直立体に変更します。

## 変更内容

Verovioは `direction/words` をデフォルトで斜体に描画するため、`words` に `font-style="normal"` 属性を指定します（Verovio 6.2.1 がこの属性を尊重し、SVGに `font-style="normal"` の rend を出力することを確認済み）。

- `mxlWords` に `font-style` 属性を追加し、常に `"normal"` を出力
- テスト期待値の更新と golden ファイルの再生成（`go test -update`）

## 検証

- `go test ./...`・`go vet ./...` 成功
- 本番と同一のコマンドライン（Verovio 6.2.1 + rsvg-convert）で es-moll・nokey の golden をレンダリングし、全コードネームが直立体で表示されることを画像で確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)